### PR TITLE
[Breaking] Add option for a different path for the static middleware and solve all the HTMLGenerator To-DOs

### DIFF
--- a/documents/options.md
+++ b/documents/options.md
@@ -73,12 +73,17 @@ These options are specifically for the Express [`static`](https://github.com/exp
   // Whether or not to enable the middleware to serve statics files.
   enabled: true,
 
-  // If true, the statics folder should be relative to the project root directory, otherwise,
-  // it should be relative to the app executable.
-  onHome: true,
+  // If true, the statics folder would be relative to the project root directory, otherwise,
+  // it would be relative to the app executable.
+  onHome: false,
 
-  // The name of your static files folder.
-  folder: 'statics',
+  // The name of both the route and the folder, relative to whatever you defined with the
+  // `onHome` option.
+  route: 'statics',
+  
+  // By default, the folder will be the same as the `route`, but you can use this option
+  // to define a relative path that won't affect the route.
+  folder: '',
 }
 ```
 

--- a/documents/services.md
+++ b/documents/services.md
@@ -311,7 +311,7 @@ Now, this service has a few default options, so instead of explaining which are,
   // The name of the generated file.
   file: 'index.html',
 
-  // Whether or not to delete the tempalte after generating the file.
+  // Whether or not to delete the template after generating the file.
   deleteTemplateAfter: true,
 
   // The placeholder string where the information will be written.
@@ -345,14 +345,11 @@ class App extends Jimpex {
     this.register(frontendFs);
     
     // Register the service
-    this.register(htmlGeneratorCustom(
-      'my-html-generator',
-      {
-        template: 'template.tpl',
-        file: 'my-index.html',
-        ...
-      }
-    ));
+    this.register(htmlGeneratorCustom({
+      template: 'template.tpl',
+      file: 'my-index.html',
+      ...
+    }));
   }
 }
 ```

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -62,8 +62,9 @@ class Jimpex extends Jimple {
       },
       statics: {
         enabled: true,
-        onHome: true,
-        folder: 'statics',
+        onHome: false,
+        route: 'statics',
+        folder: '',
       },
       filesizeLimit: '15MB',
       express: {
@@ -229,10 +230,11 @@ class Jimpex extends Jimple {
     }
 
     if (statics.enabled) {
-      const { onHome, folder } = statics;
+      const { onHome, route, folder } = statics;
       const joinFrom = onHome ? 'home' : 'app';
-      const staticsFolderPath = this.get('pathUtils').joinFrom(joinFrom, folder);
-      this.express.use(`/${folder}`, express.static(staticsFolderPath));
+      const staticsRoute = route.startsWith('/') ? route.substr(1) : route;
+      const staticsFolderPath = this.get('pathUtils').joinFrom(joinFrom, folder || staticsRoute);
+      this.express.use(`/${staticsRoute}`, express.static(staticsFolderPath));
     }
 
     if (expressOptions.bodyParser) {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -50,6 +50,7 @@ class Jimpex extends Jimple {
      */
     this.options = extend(true, {
       version: '0.0.0',
+      filesizeLimit: '15MB',
       configuration: {
         default: null,
         name: 'app',
@@ -66,7 +67,6 @@ class Jimpex extends Jimple {
         route: 'statics',
         folder: '',
       },
-      filesizeLimit: '15MB',
       express: {
         trustProxy: true,
         disableXPoweredBy: true,

--- a/src/app/typedef.js
+++ b/src/app/typedef.js
@@ -10,17 +10,17 @@
  * @property {string}  [path='config/']                    The path to the configuration files
  *                                                         directory, relative to the project root
  *                                                         directory.
- * @property {Boolean} [hasFolder=true]                    Whether the configurations are inside a
+ * @property {boolean} [hasFolder=true]                    Whether the configurations are inside a
  *                                                         sub directory or not. If `true`, a
  *                                                         configuration path would be
  *                                                         `config/[app-name]/[file]`.
  * @property {string}  [environmentVariable='CONFIG']      The name of the environment variable
  *                                                         that will be used to set the active
  *                                                         configuration.
- * @property {Boolean} [loadFromEnvironment=true]          Whether or not to check for the
+ * @property {boolean} [loadFromEnvironment=true]          Whether or not to check for the
  *                                                         environment variable and load a
  *                                                         configuration based on its value.
- * @property {Boolean} [loadVersionFromConfiguration=true] If `true`, the app `version` will be
+ * @property {boolean} [loadVersionFromConfiguration=true] If `true`, the app `version` will be
  *                                                         taken from the loaded configuration,
  *                                                         otherwise, when a configuration is
  *                                                         loaded, the app will copy the version it
@@ -32,28 +32,32 @@
 
 /**
  * @typedef {Object} JimpexStaticsOptions
- * @property {Boolean} [enabled=true]    Whether or not to include the middleware for static files.
- * @property {Boolean} [onHome=true]     If `true`, the path to the statics folder will be relative
+ * @property {boolean} [enabled=true]    Whether or not to include the middleware for static files.
+ * @property {boolean} [onHome=false]    If `true`, the path to the statics folder will be relative
  *                                       to the project root directory, otherwise, it will be
  *                                       relative to the directory where the app executable file is
  *                                       located.
- * @property {string}  [folder='static'] The name of the folder for static files.
+ * @property {string}  [route='static']  The name of both the route and the folder, relative to
+ *                                       whatever you defined with the `onHome` option.
+ * @property {string}  [folder='']       By default, the folder will be the same as the `route`,
+ *                                       but you can use this option to define a relative path that
+ *                                       won't affect the route.
  */
 
 /**
  * @typedef {Object} JimpexExpressOptions
- * @property {Boolean} [trustProxy=true]        Whether or not to enable the `trust proxy` option.
- * @property {Boolean} [disableXPoweredBy=true] Whether or not to remove the `x-powered-by` header.
- * @property {Boolean} [compression=true]       Whether or not to add the `compression` middleware.
- * @property {Boolean} [bodyParser=true]        Whether or not to add the `body-parser` middleware.
- * @property {Boolean} [multer=true]            Whether or not to add the `multer` middleware.
+ * @property {boolean} [trustProxy=true]        Whether or not to enable the `trust proxy` option.
+ * @property {boolean} [disableXPoweredBy=true] Whether or not to remove the `x-powered-by` header.
+ * @property {boolean} [compression=true]       Whether or not to add the `compression` middleware.
+ * @property {boolean} [bodyParser=true]        Whether or not to add the `body-parser` middleware.
+ * @property {boolean} [multer=true]            Whether or not to add the `multer` middleware.
  */
 
 /**
  * @typedef {Object} JimpexDefaultServicesOptions
- * @property {Boolean} [common=true] Whether or not to register all the `common` service providers.
- * @property {Boolean} [http=true]   Whether or not to register all the `http` service providers.
- * @property {Boolean} [api=true]    Whether or not to register all the `api` service providers.
+ * @property {boolean} [common=true] Whether or not to register all the `common` service providers.
+ * @property {boolean} [http=true]   Whether or not to register all the `http` service providers.
+ * @property {boolean} [api=true]    Whether or not to register all the `api` service providers.
  */
 
 /**

--- a/src/controllers/common/rootStatics.js
+++ b/src/controllers/common/rootStatics.js
@@ -9,17 +9,17 @@ const { controller } = require('../../utils/wrappers');
 class RootStaticsController {
   /**
    * Class constructor.
-   * @param {SendFile} sendFile                              To be able to send the files as
-   *                                                         responses.
-   * @param {Array}   [files=['index.html', 'favicon.icon']] The list of files to serve. Each item
-   *                                                         can be a `string` or an `Object` with
-   *                                                         the keys `origin` for the file route,
-   *                                                         `output` for the file location
-   *                                                         relative to the root, and `headers`
-   *                                                         with the file custom headers for the
-   *                                                         response.
+   * @param {SendFile} sendFile                             To be able to send the files as
+   *                                                        responses.
+   * @param {Array}   [files=['index.html', 'favicon.ico']] The list of files to serve. Each item
+   *                                                        can be a `string` or an `Object` with
+   *                                                        the keys `origin` for the file route,
+   *                                                        `output` for the file location
+   *                                                        relative to the root, and `headers`
+   *                                                        with the file custom headers for the
+   *                                                        response.
    */
-  constructor(sendFile, files = ['index.html', 'favicon.icon']) {
+  constructor(sendFile, files = ['index.html', 'favicon.ico']) {
     /**
      * A local reference for the `sendFile` service.
      * @type {SendFile}

--- a/src/services/html/htmlGenerator.js
+++ b/src/services/html/htmlGenerator.js
@@ -36,7 +36,6 @@ const { provider } = require('../../utils/wrappers');
 class HTMLGenerator {
   /**
    * Class constructor.
-   * @param {HTMLGeneratorOptions}        [options]            To customize the service.
    * @param {AppConfiguration}            appConfiguration     To read the values of the settings
    *                                                           that are going to be send to the
    *                                                           file.
@@ -45,6 +44,7 @@ class HTMLGenerator {
    *                                                           removed, and if it happens, when
    *                                                           an error is thrown.
    * @param {FrontendFs}                  frontendFs           To read the contents of the template.
+   * @param {HTMLGeneratorOptions}        [options]            To customize the service.
    * @param {?HTMLGeneratorValuesService} [valuesService=null] If specified, instead of getting
    *                                                           the values from the app
    *                                                           configuration, they'll be retrieved
@@ -229,9 +229,9 @@ class HTMLGenerator {
  * Generates an `HTMLGenerator` service provider with customized options and that automatically
  * hooks itself to the `after-start` event of the app server in order to trigger the generation of
  * the html file when the server starts.
+ * @param {HTMLGeneratorOptions}  [options={}]                  Options to customize the service.
  * @param {string}                [serviceName='htmlGenerator'] The name of the service that will
  *                                                              be register into the app.
- * @param {HTMLGeneratorOptions}  [options={}]                  Options to customize the service.
  * @param {?string}               [valuesServiceName=null]      The name of a service used to read
  *                                                              the values that will be injected in
  *                                                              the generated file.

--- a/src/services/html/htmlGenerator.js
+++ b/src/services/html/htmlGenerator.js
@@ -50,13 +50,12 @@ class HTMLGenerator {
    *                                                           configuration, they'll be retrieved
    *                                                           from this service `getValues` method.
    * @throws {Error} if `valuesService` is specified but it doesn't have a `getValues` method.
-   * @todo Move `options` to the before last parameter as it's optional
    */
   constructor(
-    options,
     appConfiguration,
     appLogger,
     frontendFs,
+    options,
     valuesService = null
   ) {
     /**
@@ -204,9 +203,8 @@ class HTMLGenerator {
       /**
        * If the template needs to be deleted, return the call to the `delete` method, otherwise,
        * just an empty object to continue the promise chain.
-       * @todo Change it to a short circuit evaluation.
        */
-      return deleteTemplateAfter ? this.frontendFs.delete(`./${template}`) : {};
+      return deleteTemplateAfter && this.frontendFs.delete(`./${template}`);
     })
     .then(() => {
       // If the template was deleted, log a message informing it.
@@ -238,12 +236,10 @@ class HTMLGenerator {
  *                                                              the values that will be injected in
  *                                                              the generated file.
  * @return {Provider}
- * @todo Move `serviceName` as the second parameter in case the implementation wants to change just
- *       the options.
  */
 const htmlGeneratorCustom = (
-  serviceName = 'htmlGenerator',
   options = {},
+  serviceName = 'htmlGenerator',
   valuesServiceName = null
 ) => provider((app) => {
   app.set(serviceName, () => {
@@ -253,10 +249,10 @@ const htmlGeneratorCustom = (
     }
 
     return new HTMLGenerator(
-      options,
       app.get('appConfiguration'),
       app.get('appLogger'),
       app.get('frontendFs'),
+      options,
       valuesService
     );
   });

--- a/tests/services/html/htmlGenerator.test.js
+++ b/tests/services/html/htmlGenerator.test.js
@@ -26,10 +26,10 @@ describe('services/html:htmlGenerator', () => {
     let sut = null;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
-      frontendFs
+      frontendFs,
+      options
     );
     // Then
     expect(sut).toBeInstanceOf(HTMLGenerator);
@@ -59,10 +59,10 @@ describe('services/html:htmlGenerator', () => {
     let sut = null;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
       frontendFs,
+      options,
       valuesService
     );
     // Then
@@ -83,10 +83,10 @@ describe('services/html:htmlGenerator', () => {
     const valuesService = {};
     // When/Then
     expect(() => new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
       frontendFs,
+      options,
       valuesService
     ))
     .toThrow(/The HTMLGenerator values service must have a `getValues` method/i);
@@ -103,10 +103,10 @@ describe('services/html:htmlGenerator', () => {
     let result = null;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
-      frontendFs
+      frontendFs,
+      options
     );
     result = sut.getFile();
     // Then
@@ -125,10 +125,10 @@ describe('services/html:htmlGenerator', () => {
     let sut = null;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
-      frontendFs
+      frontendFs,
+      options
     );
     return sut.getValues()
     .then((result) => {
@@ -155,10 +155,10 @@ describe('services/html:htmlGenerator', () => {
     let sut = null;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
       frontendFs,
+      options,
       valuesService
     );
     return sut.getValues()
@@ -184,10 +184,10 @@ describe('services/html:htmlGenerator', () => {
     let sut = null;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
-      frontendFs
+      frontendFs,
+      options
     );
     return sut.getValues()
     .then((result) => {
@@ -209,10 +209,10 @@ describe('services/html:htmlGenerator', () => {
     let result = null;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
-      frontendFs
+      frontendFs,
+      options
     );
     result = sut.whenReady();
     // Then
@@ -248,10 +248,10 @@ describe('services/html:htmlGenerator', () => {
     const expectedContent = `window.${options.variable} = ${JSON.stringify(values)}`;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
-      frontendFs
+      frontendFs,
+      options
     );
     return sut.generateHTML()
     .then(() => {
@@ -305,10 +305,10 @@ describe('services/html:htmlGenerator', () => {
     const expectedContent = `window.${options.variable} = ${JSON.stringify(values)}`;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
-      frontendFs
+      frontendFs,
+      options
     );
     return sut.generateHTML()
     .then(() => {
@@ -348,10 +348,10 @@ describe('services/html:htmlGenerator', () => {
     let sut = null;
     // When
     sut = new HTMLGenerator(
-      options,
       appConfiguration,
       appLogger,
-      frontendFs
+      frontendFs,
+      options
     );
     return sut.generateHTML()
     .then(() => {
@@ -401,7 +401,7 @@ describe('services/html:htmlGenerator', () => {
     let eventName = null;
     let eventFn = null;
     // When
-    htmlGeneratorCustom(name)(app);
+    htmlGeneratorCustom({}, name)(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     [[eventName, eventFn]] = events.once.mock.calls;
     sut = serviceFn();
@@ -471,7 +471,7 @@ describe('services/html:htmlGenerator', () => {
     const expectedGets = Object.keys(services);
     const expectedEventName = 'after-start';
     // When
-    htmlGeneratorCustom(name, {}, myValuesServiceName)(app);
+    htmlGeneratorCustom({}, name, myValuesServiceName)(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     [[eventName, eventFn]] = events.once.mock.calls;
     sut = serviceFn();


### PR DESCRIPTION
### What does this PR do?

#### Add an option for a different path on the `static` middleware

Before this change, if you were to set the `statics.folder` to, let's say, `my-statics`, the middleware would be mounted on the route `my-statics` and the path would be `./my-statics`, relative to whatever you set on the `statics.onHome` option.

Now, `statics.folder` has been changed to `statics.route` and a `statics.folder` is empty, because by default you would change the route and it will also affect the folder, but because they are now two options, you can set the route to `my-statics` and keep the folder pointing to `./some-other-folder`.

#### The path for the `static` middleware folder is now relative to the app executable

When I set the default to be relative to the project root directory (`statics.onHome = true`), I didn't consider that the most common case would be for the app code to be inside a `src`/`server`/`app` folder and then, if needed, probably moved to a `dist`/`build`/`deploy` folder.

So now the `statics.onHome` option is set to `false` by default, and if there's a case where your project has all the app files mixed with the other project files (like the `package.json`, `.gitignore`, `.editorconfig`, etc), you can set it to `true`.

#### Fixes for the `HTMLGenerator`

- On the `HTMLGenerator` class constructor, the `options` parameter has been moved from the first on the list to the one before the last one. `options` is not a required parameter, so it shouldn't have been before required parameters.
- On the `htmlGeneratorCustom` _"provider generator"_, `serviceName` has been moved from the first parameter to the second parameter as I consider the most common case would be to change the options of the default services, not rename it.

### How should it be tested manually?

```bash
yarn test
# or
npm test
