### PR TITLE
Add the possiblity to replace single values on the HTML Generator template

### DIFF
--- a/documents/services.md
+++ b/documents/services.md
@@ -26,7 +26,7 @@ class App extends Jimpex {
     // Register the dependencies...
     this.register(http);
     this.register(appError);
-        
+
     // Register the client
     this.register(apiClient);
   }
@@ -50,7 +50,7 @@ class App extends Jimpex {
     // Register the dependencies...
     this.register(http);
     this.register(appError);
-        
+
     // Register the client
     this.register({
       'myCustomAPIService',
@@ -84,7 +84,7 @@ class App extends Jimpex {
   boot() {
     // Register the dependencies...
     this.register(appError);
-        
+
     // Register the service
     this.register(apiClient);
   }
@@ -131,7 +131,7 @@ class App extends Jimpex {
     // Register the dependencies...
     this.register(appError);
     this.register(responsesBuilder);
-        
+
     // Register the service
     this.register(versionValidator);
   }
@@ -292,7 +292,7 @@ class App extends Jimpex {
   boot() {
     // Register the dependencies...
     this.register(frontendFs);
-    
+
     // Register the service
     this.register(htmlGenerator);
   }
@@ -316,6 +316,9 @@ Now, this service has a few default options, so instead of explaining which are,
 
   // The placeholder string where the information will be written.
   replacePlaceholder: '{{appConfiguration}}',
+
+  // A dynamic placeholder to replace single values on the template.
+  valuesExpression: /\{\{(.*?)\}\}/ig,
 
   // The name of the variable that will have the information on the file.
   variable: 'appConfiguration',
@@ -343,7 +346,7 @@ class App extends Jimpex {
   boot() {
     // Register the dependencies...
     this.register(frontendFs);
-    
+
     // Register the service
     this.register(htmlGeneratorCustom({
       template: 'template.tpl',


### PR DESCRIPTION
### What does this PR do?

Until now, you could only write the values placeholder on the HTML Generator template and that alone would be replaced when the file was created, but now you can use placeholders for single values too:

```html
<script>
{{appConfiguration}};

if ({{someFeature.enabled}}) {
  console.log('Do something!');
}
</script>
```

Assuming you are using the default configuration...

1. `{{appConfiguration}}` will be replaced with the entire values object.
2. `{{someFeature.enabled}}` will be replaced with the value of `[valuesObj].someFeature.enabled`.

Like the main placeholder, you can also change the way the values are identified using the new `valuesExpression` option, which receives a `RegExp` that needs to capture at least one group.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
