### PR TITLE
feat(app): add a listen method

### DIFF
--- a/README-esdoc.md
+++ b/README-esdoc.md
@@ -82,7 +82,8 @@ app.start(() => {
 });
 ```
 
-> And like Express, you can send a callback to be executed after the server starts.
+> - Like Express, you can send a callback to be executed after the server starts.
+> - You also have a `listen` alias with the same signature as express (port and callback) for serverless platforms where you don't manually start the app.
 
 You can also stop the app by calling `stop()`:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ app.start(() => {
 });
 ```
 
-> And like Express, you can send a callback to be executed after the server starts.
+> - Like Express, you can send a callback to be executed after the server starts.
+> - You also have a `listen` alias with the same signature as express (port and callback) for serverless platforms where you don't manually start the app.
 
 You can also stop the app by calling `stop()`:
 

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -164,6 +164,22 @@ class Jimpex extends Jimple {
     return this.instance;
   }
   /**
+   * This is an alias of `start`. The idea is for it to be used on serverless platforms, where you
+   * don't get to start your app, you just have export it.
+   * @param {number}                            port The port where the app will run. In case the
+   *                                                 rest of the app needs to be aware of the port,
+   *                                                 this method will overwrite the `port` setting
+   *                                                 on the configuration.
+   * @param {function(config:AppConfiguration)} [fn] A callback function to be called when the
+   *                                                 server starts.
+   * @return {Object} The server instance
+   */
+  listen(port, fn = () => {}) {
+    const config = this.get('appConfiguration');
+    config.set('port', port);
+    return this.start(fn, port);
+  }
+  /**
    * Emit an app event with a reference to this class instance.
    * @param {string} name The name of the event.
    */

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -734,7 +734,7 @@ describe('app:Jimpex', () => {
     expect(expressMock.mocks.closeInstance).toHaveBeenCalledTimes(1);
   });
 
-  it('should start the server an fire a custom callback', () => {
+  it('should start the server and fire a custom callback', () => {
     // Given
     class Sut extends Jimpex {
       boot() {}
@@ -770,6 +770,99 @@ describe('app:Jimpex', () => {
     // Then
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith(appConfiguration);
+  });
+
+  it('should start the server using `listen`', () => {
+    // Given
+    class Sut extends Jimpex {
+      boot() {}
+    }
+    const pathUtils = {
+      joinFrom: jest.fn((from, rest) => path.join(from, rest)),
+    };
+    JimpleMock.service('pathUtils', pathUtils);
+    const defaultConfig = {};
+    const rootRequire = jest.fn(() => defaultConfig);
+    JimpleMock.service('rootRequire', rootRequire);
+    const customPort = 8080;
+    const configuration = {
+      port: 2509,
+      changes: {},
+    };
+    const appConfiguration = {
+      loadFromEnvironment: jest.fn(),
+      get: jest.fn((prop) => configuration.changes[prop] || configuration[prop]),
+      set: jest.fn((prop, value) => {
+        configuration.changes[prop] = value;
+      }),
+    };
+    JimpleMock.service('appConfiguration', appConfiguration);
+    const events = {
+      emit: jest.fn(),
+    };
+    JimpleMock.service('events', events);
+    const appLogger = {
+      success: jest.fn(),
+    };
+    JimpleMock.service('appLogger', appLogger);
+    let sut = null;
+    // When
+    sut = new Sut();
+    sut.listen(customPort);
+    // Then
+    expect(appLogger.success).toHaveBeenCalledTimes(1);
+    expect(appLogger.success).toHaveBeenCalledWith(`Starting on port ${customPort}`);
+    expect(appConfiguration.set).toHaveBeenCalledTimes(1);
+    expect(appConfiguration.set).toHaveBeenCalledWith('port', customPort);
+    expect(configuration.changes.port).toBe(customPort);
+  });
+
+  it('should start the server using `listen` and fire a custom callback', () => {
+    // Given
+    class Sut extends Jimpex {
+      boot() {}
+    }
+    const pathUtils = {
+      joinFrom: jest.fn((from, rest) => path.join(from, rest)),
+    };
+    JimpleMock.service('pathUtils', pathUtils);
+    const defaultConfig = {};
+    const rootRequire = jest.fn(() => defaultConfig);
+    JimpleMock.service('rootRequire', rootRequire);
+    const customPort = 8080;
+    const configuration = {
+      port: 2509,
+      changes: {},
+    };
+    const appConfiguration = {
+      loadFromEnvironment: jest.fn(),
+      get: jest.fn((prop) => configuration.changes[prop] || configuration[prop]),
+      set: jest.fn((prop, value) => {
+        configuration.changes[prop] = value;
+      }),
+    };
+    JimpleMock.service('appConfiguration', appConfiguration);
+    const events = {
+      emit: jest.fn(),
+    };
+    JimpleMock.service('events', events);
+    const appLogger = {
+      success: jest.fn(),
+    };
+    JimpleMock.service('appLogger', appLogger);
+    const callback = jest.fn();
+    let sut = null;
+    // When
+    sut = new Sut();
+    sut.listen(customPort, callback);
+    // Then
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(appConfiguration);
+    expect(appLogger.success).toHaveBeenCalledTimes(1);
+    expect(appLogger.success).toHaveBeenCalledWith(`Starting on port ${customPort}`);
+    expect(appConfiguration.set).toHaveBeenCalledTimes(1);
+    expect(appConfiguration.set).toHaveBeenCalledWith('port', customPort);
+    expect(configuration.changes.port).toBe(customPort);
   });
 
   it('shouldn\'t do anything when trying to stop the server without starting it', () => {


### PR DESCRIPTION
### What does this PR do?

It adds a `listen` method that works like an alias for `start`. The idea is for it to be used on serverless platforms where you don't get to start the app, you just export it and the platform takes care of the rest.

The new method follows the same signature as the the `http` module and Express: it accepts a `port` and a `callback`, and it returns the instance of the server.

### How should it be tested manually?

Try running your app by calling `listen` instead of `start`, and don't forget to send the port, which is required.

```js
app.listen(8080, () => {
  console.log('Yay!');
}):
```
And of course...

```bash
yarn test
# or
npm test
```