### PR TITLE
refactor(project): use wootils' ObjectUtils instead of extend

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
       "express": "^4.17.1",
       "body-parser": "^1.19.0",
       "compression": "^1.7.4",
-      "extend": "^3.0.2",
       "node-fetch": "^2.6.0",
       "urijs": "^1.19.1",
       "statuses": "^1.5.0",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,5 +1,5 @@
 const Jimple = require('jimple');
-const extend = require('extend');
+const ObjectUtils = require('wootils/shared/objectUtils');
 const express = require('express');
 const bodyParser = require('body-parser');
 const compression = require('compression');
@@ -48,7 +48,7 @@ class Jimpex extends Jimple {
      * The app options.
      * @type {JimpexOptions}
      */
-    this.options = extend(true, {
+    this.options = ObjectUtils.merge({
       version: '0.0.0',
       filesizeLimit: '15MB',
       configuration: {

--- a/src/controllers/common/rootStatics.js
+++ b/src/controllers/common/rootStatics.js
@@ -1,4 +1,4 @@
-const extend = require('extend');
+const ObjectUtils = require('wootils/shared/objectUtils');
 const mime = require('mime');
 const { controller } = require('../../utils/wrappers');
 /**
@@ -53,7 +53,7 @@ class RootStaticsController {
       const item = this.files[file];
       const extension = item.output.split('.').pop().toLowerCase();
       const baseHeaders = { 'Content-Type': mime.getType(extension) };
-      const headers = extend(true, baseHeaders, item.headers);
+      const headers = ObjectUtils.merge(baseHeaders, item.headers);
 
       Object.keys(headers).forEach((headerName) => {
         res.setHeader(headerName, headers[headerName]);

--- a/src/services/html/htmlGenerator.js
+++ b/src/services/html/htmlGenerator.js
@@ -1,4 +1,4 @@
-const extend = require('extend');
+const ObjectUtils = require('wootils/shared/objectUtils');
 const { deferred } = require('wootils/shared');
 const { provider } = require('../../utils/wrappers');
 /**
@@ -66,7 +66,7 @@ class HTMLGenerator {
      * The service options.
      * @type {HTMLGeneratorOptions}
      */
-    this.options = extend({
+    this.options = ObjectUtils.merge({
       template: 'index.tpl.html',
       file: 'index.html',
       deleteTemplateAfter: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,7 +2512,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.2, extend@~3.0.2:
+extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==


### PR DESCRIPTION
### What does this PR do?

[Wootils' ObjectUtils](https://homer0.github.io/wootils/manual/objectUtils.html) is already a wrapper on top of [extend](http://yarnpkg.com/en/package/extend), so on this PR I replaced every call to extend with `ObjectUtils.merge`.

### How should it be tested manually?

This shouldn't change anything for your app, as `merge` does internally the same I was doing with extend. In any case...

```bash
yarn test
# or
npm test
```