### PR TITLE
feat(project): enhance the controllers, middlewares and providers

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -278,15 +278,15 @@ class Jimpex extends Jimple {
     const { defaultServices } = this.options;
 
     if (defaultServices.api) {
-      this.register(apiServices.all);
+      this.register(apiServices);
     }
 
     if (defaultServices.common) {
-      this.register(commonServices.all);
+      this.register(commonServices);
     }
 
     if (defaultServices.http) {
-      this.register(httpServices.all);
+      this.register(httpServices);
     }
 
     this.set('events', () => new EventsHub());

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -119,8 +119,8 @@ class Jimpex extends Jimple {
   }
   /**
    * Mount a controller on a route point.
-   * @param {string}     point      The route for the controller.
-   * @param {Controller} controller The route controller.
+   * @param {string}                       point      The route for the controller.
+   * @param {Controller|ControllerCreator} controller The route controller.
    */
   mount(point, controller) {
     this.mountQueue.push(
@@ -131,7 +131,7 @@ class Jimpex extends Jimple {
   }
   /**
    * Add a middleware.
-   * @param {Middleware} middleware [description]
+   * @param {Middleware|MiddlewareCreator} middleware The middleware to use.
    */
   use(middleware) {
     this.mountQueue.push((server) => {

--- a/src/controllers/common/index.js
+++ b/src/controllers/common/index.js
@@ -1,13 +1,9 @@
 const { configurationController } = require('./configuration');
 const { healthController } = require('./health');
-const {
-  rootStaticsController,
-  rootStaticsControllerCustom,
-} = require('./rootStatics');
+const { rootStaticsController } = require('./rootStatics');
 
 module.exports = {
   configurationController,
   healthController,
   rootStaticsController,
-  rootStaticsControllerCustom,
 };

--- a/src/controllers/common/rootStatics.js
+++ b/src/controllers/common/rootStatics.js
@@ -1,6 +1,6 @@
 const ObjectUtils = require('wootils/shared/objectUtils');
 const mime = require('mime');
-const { controller } = require('../../utils/wrappers');
+const { controllerCreator } = require('../../utils/wrappers');
 /**
  * Since the static files are inside a folder and we can't have the the `static` middleware pointing
  * to the app root directory, this service allows you to serve static files that are on the root
@@ -95,28 +95,24 @@ class RootStaticsController {
   }
 }
 /**
- * Generates a controller with an already defined list of files.
- * The controller will get all the files, add route for each one of them and include a middleware
- * provided by the `RootStaticsController` in order to serve them.
+ * This controller can be used to serve files from the root directory; the idea is to avoid
+ * declaring the root directory as a static folder.
+ * The files are sent to {@link RootStaticsController} and for each file, it will declare a route
+ * and mount a middleware in order to serve them.
+ * @type {ControllerCreator}
  * @param {Array} files The list of files. Each item can be a `string` or an `Object` with the
  *                      keys `origin` for the file route, `output` for the file location relative
- *                      to the root, and `headers` with the file custom headers for the response.
- * @return {Controller}
+ *                      to the root, and `headers` with the file custom headers in case they are
+ *                      needed on the response.
  */
-const rootStaticsControllerCustom = (files) => controller((app) => {
+const rootStaticsController = controllerCreator((files) => (app) => {
   const router = app.get('router');
   const ctrl = new RootStaticsController(app.get('sendFile'), files);
   return ctrl.getFileEntries()
   .map((file) => router.all(`/${file}`, ctrl.serveFile(file)));
 });
-/**
- * Mount a controller to serve an `index.html` and `favicon.ico` files from the root directory.
- * @type {Controller}
- */
-const rootStaticsController = rootStaticsControllerCustom();
 
 module.exports = {
   RootStaticsController,
   rootStaticsController,
-  rootStaticsControllerCustom,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const services = require('./services');
 const {
   provider,
   providerCreator,
+  providers,
   controller,
   controllerCreator,
   middleware,
@@ -20,6 +21,7 @@ module.exports = {
   middlewares,
   provider,
   providerCreator,
+  providers,
   services,
   Jimpex,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,16 +4,22 @@ const middlewares = require('./middlewares');
 const services = require('./services');
 const {
   provider,
+  providerCreator,
   controller,
+  controllerCreator,
   middleware,
+  middlewareCreator,
 } = require('./utils/wrappers');
 
 module.exports = {
-  Jimpex,
-  provider,
-  controllers,
-  middlewares,
-  services,
   controller,
+  controllerCreator,
+  controllers,
   middleware,
+  middlewareCreator,
+  middlewares,
+  provider,
+  providerCreator,
+  services,
+  Jimpex,
 };

--- a/src/middlewares/common/errorHandler.js
+++ b/src/middlewares/common/errorHandler.js
@@ -1,6 +1,6 @@
 const ObjectUtils = require('wootils/shared/objectUtils');
 const statuses = require('statuses');
-const { middleware } = require('../../utils/wrappers');
+const { middlewareCreator } = require('../../utils/wrappers');
 
 /**
  * @typedef {Object} ErrorHandlerDefaultOptions
@@ -138,11 +138,11 @@ class ErrorHandler {
   }
 }
 /**
- * Generates a middleware that generates responses for unhandled errors thrown by the app.
+ * Generates a middleware that show responses for unhandled errors thrown by the app.
+ * @type {MiddlewareCreator}
  * @param {ErrorHandlerOptions} [options] Custom options to modify the middleware behavior.
- * @return {Middleware}
  */
-const errorHandlerCustom = (options) => middleware((app) => {
+const errorHandler = middlewareCreator((options) => (app) => {
   const debugging = app.get('appConfiguration').get('debug');
   const showErrors = debugging && debugging.showErrors;
   return new ErrorHandler(
@@ -155,14 +155,7 @@ const errorHandlerCustom = (options) => middleware((app) => {
   .middleware();
 });
 
-/**
- * This middleware generates responses for unhandled errors thrown by the app.
- * @type {Middleware}
- */
-const errorHandler = errorHandlerCustom();
-
 module.exports = {
   ErrorHandler,
   errorHandler,
-  errorHandlerCustom,
 };

--- a/src/middlewares/common/forceHTTPS.js
+++ b/src/middlewares/common/forceHTTPS.js
@@ -1,4 +1,4 @@
-const { middleware } = require('../../utils/wrappers');
+const { middlewareCreator } = require('../../utils/wrappers');
 /**
  * Force all the app traffice to be through HTTPS.
  */
@@ -35,24 +35,18 @@ class ForceHTTPS {
   }
 }
 /**
- * Generates a middleware with an already defined list of ignored routes expressions.
+ * A middleware to force HTTPS redirections to all the routes.
+ * @type {MiddlewareCreator}
  * @param {Array} ignoredRoutes A list of regular expressions to match routes that should be
  *                              ignored.
- * @return {Middleware}
  */
-const forceHTTPSCustom = (ignoredRoutes) => middleware((app) => (
+const forceHTTPS = middlewareCreator((ignoredRoutes) => (app) => (
   app.get('appConfiguration').get('forceHTTPS') ?
     new ForceHTTPS(ignoredRoutes).middleware() :
     null
 ));
-/**
- * A middleware to force HTTPS redirections to all the routes.
- * @type {Middleware}
- */
-const forceHTTPS = forceHTTPSCustom();
 
 module.exports = {
   ForceHTTPS,
   forceHTTPS,
-  forceHTTPSCustom,
 };

--- a/src/middlewares/common/index.js
+++ b/src/middlewares/common/index.js
@@ -1,8 +1,7 @@
 const { errorHandler } = require('./errorHandler');
-const { forceHTTPS, forceHTTPSCustom } = require('./forceHTTPS');
+const { forceHTTPS } = require('./forceHTTPS');
 
 module.exports = {
   errorHandler,
   forceHTTPS,
-  forceHTTPSCustom,
 };

--- a/src/middlewares/common/index.js
+++ b/src/middlewares/common/index.js
@@ -1,9 +1,8 @@
-const { errorHandler, errorHandlerCustom } = require('./errorHandler');
+const { errorHandler } = require('./errorHandler');
 const { forceHTTPS, forceHTTPSCustom } = require('./forceHTTPS');
 
 module.exports = {
   errorHandler,
-  errorHandlerCustom,
   forceHTTPS,
   forceHTTPSCustom,
 };

--- a/src/middlewares/html/fastHTML.js
+++ b/src/middlewares/html/fastHTML.js
@@ -1,5 +1,5 @@
 const mime = require('mime');
-const { middleware } = require('../../utils/wrappers');
+const { middlewareCreator } = require('../../utils/wrappers');
 /**
  * It's common for an app to show an HTML view when no route was able to handle a request, so the
  * idea behind this middleware is to avoid going to every middleware and controller and just
@@ -124,7 +124,9 @@ class FastHTML {
   }
 }
 /**
- * Generates a middleware with customized options.
+ * A middleware for filtering routes and serve an HTML file when the requested route doesn't have
+ * a controller to handle it.
+ * @type {MiddlewareCreator}
  * @param {string} [file]                                     The name of the file it will serve.
  *                                                            If the `HTMLGenerator` service
  *                                                            specified is avaialable, this will
@@ -138,13 +140,12 @@ class FastHTML {
  *                                                            registered on the app, it won't throw
  *                                                            an error, but just send `null` to
  *                                                            the service constructor.
- * @return {Middleware}
  */
-const fastHTMLCustom = (
+const fastHTML = middlewareCreator((
   file,
   ignoredRoutes,
   htmlGeneratorServiceName = 'htmlGenerator'
-) => middleware((app) => {
+) => (app) => {
   let htmlGenerator;
   try {
     htmlGenerator = app.get(htmlGeneratorServiceName);
@@ -159,15 +160,8 @@ const fastHTMLCustom = (
     htmlGenerator
   ).middleware();
 });
-/**
- * A middleware for filtering routes and serve an HTML file when the requested route doesn't have
- * a controller to handle it.
- * @type {Middleware}
- */
-const fastHTML = fastHTMLCustom();
 
 module.exports = {
   FastHTML,
   fastHTML,
-  fastHTMLCustom,
 };

--- a/src/middlewares/html/index.js
+++ b/src/middlewares/html/index.js
@@ -1,9 +1,8 @@
-const { fastHTML, fastHTMLCustom } = require('./fastHTML');
+const { fastHTML } = require('./fastHTML');
 const { showHTML, showHTMLCustom } = require('./showHTML');
 
 module.exports = {
   fastHTML,
-  fastHTMLCustom,
   showHTML,
   showHTMLCustom,
 };

--- a/src/middlewares/html/index.js
+++ b/src/middlewares/html/index.js
@@ -1,8 +1,7 @@
 const { fastHTML } = require('./fastHTML');
-const { showHTML, showHTMLCustom } = require('./showHTML');
+const { showHTML } = require('./showHTML');
 
 module.exports = {
   fastHTML,
   showHTML,
-  showHTMLCustom,
 };

--- a/src/middlewares/html/showHTML.js
+++ b/src/middlewares/html/showHTML.js
@@ -1,5 +1,5 @@
 const mime = require('mime');
-const { middleware } = require('../../utils/wrappers');
+const { middlewareCreator } = require('../../utils/wrappers');
 /**
  * A very simple middleware service to send an HTML on a server response. The special _'feature'_ of
  * this service is that it can be hooked up to an `HTMLGenerator` service and it will automatically
@@ -96,7 +96,8 @@ class ShowHTML {
   }
 }
 /**
- * Generates a middleware with customized options.
+ * A middleware for showing an `index.html` file.
+ * @type {MiddlewareCreator}
  * @param {string} [file]                                     The name of the file it will serve.
  *                                                            If the `HTMLGenerator` service
  *                                                            specified is avaialable, this will
@@ -107,12 +108,11 @@ class ShowHTML {
  *                                                            registered on the app, it won't throw
  *                                                            an error, but just send `null` to
  *                                                            the service constructor.
- * @return {Middleware}
  */
-const showHTMLCustom = (
+const showHTML = middlewareCreator((
   file,
   htmlGeneratorServiceName = 'htmlGenerator'
-) => middleware((app) => {
+) => (app) => {
   let htmlGenerator;
   try {
     htmlGenerator = app.get(htmlGeneratorServiceName);
@@ -126,14 +126,8 @@ const showHTMLCustom = (
     htmlGenerator
   ).middleware();
 });
-/**
- * A middleware for showing an `index.html` file.
- * @type {Middleware}
- */
-const showHTML = showHTMLCustom();
 
 module.exports = {
   ShowHTML,
   showHTML,
-  showHTMLCustom,
 };

--- a/src/middlewares/utils/index.js
+++ b/src/middlewares/utils/index.js
@@ -1,6 +1,5 @@
-const { versionValidator, versionValidatorCustom } = require('./versionValidator');
+const { versionValidator } = require('./versionValidator');
 
 module.exports = {
   versionValidator,
-  versionValidatorCustom,
 };

--- a/src/middlewares/utils/versionValidator.js
+++ b/src/middlewares/utils/versionValidator.js
@@ -1,6 +1,6 @@
 const ObjectUtils = require('wootils/shared/objectUtils');
 const statuses = require('statuses');
-const { middleware } = require('../../utils/wrappers');
+const { middlewareCreator } = require('../../utils/wrappers');
 
 /**
  * @typdef {Object} VersionValidatorLatestOptions
@@ -192,18 +192,19 @@ class VersionValidator {
   }
 }
 /**
- * Generates a middleware/controller with customized options.
- * The reason for "middleware/controller" is because the wrappers for both are the same, the
+ * A middleware that will validate a `version` request parameter against the app version and
+ * generate an error if they don't match.
+ * This is a "middleware/controller" is because the wrappers for both are the same, the
  * difference is that, for controllers, Jimpex sends a second parameter with the point where they
  * are mounted.
  * By validating the point parameter, the function can know whether the implementation is going
  * to use the middleware by itself or as a route middleware.
  * If used as middleware, it will just return the result of {@link VersionValidator#middleware};
  * but if used as controller, it will mount it on `[point]/:version/*`.
+ * @type {MiddlewareCreator}
  * @param {VersionValidatorOptions} [options] Custom options to modify the middleware behavior.
- * @return {Middleware}
  */
-const versionValidatorCustom = (options) => middleware((app, point) => {
+const versionValidator = middlewareCreator((options) => (app, point) => {
   // Get the middleware function.
   const middlewareValidator = (new VersionValidator(
     app.get('appConfiguration').get('version'),
@@ -228,15 +229,8 @@ const versionValidatorCustom = (options) => middleware((app, point) => {
   // Return the route or the middleware.
   return result;
 });
-/**
- * A middleware that will validate a `version` request parameter against the app version and
- * generate an error if they don't match.
- * @var  {Middleware}
- */
-const versionValidator = versionValidatorCustom();
 
 module.exports = {
   VersionValidator,
   versionValidator,
-  versionValidatorCustom,
 };

--- a/src/services/api/client.js
+++ b/src/services/api/client.js
@@ -1,5 +1,5 @@
 const APIClientBase = require('wootils/shared/apiClient');
-const { provider } = require('../../utils/wrappers');
+const { providerCreator } = require('../../utils/wrappers');
 /**
  * An API client for the app to use. What makes this service special is that its that it formats
  * the received errors using the `AppError` service class and as fetch function it uses the
@@ -45,40 +45,28 @@ class APIClient extends APIClientBase {
   }
 }
 /**
- * Generates a provider with customized options. This allows the app to have multiple clients for
- * different APIs.
+ * An API Client service to make requests to an API using endpoints defined on the app
+ * configuration.
+ * @type {ProviderCreator}
  * @param {string} [name='apiClient']       The name of the service that will be registered into
  *                                          the app.
  * @param {string} [configurationKey='api'] The name of the app configuration setting that has the
  *                                          API information.
  * @param {Class}  [ClientClass=APIClient]  The Class the service will instantiate.
- * @return {Provider}
  */
-const apiClientCustom = (
+const apiClient = providerCreator((
   name = 'apiClient',
   configurationKey = 'api',
   ClientClass = APIClient
-) => provider((app) => {
+) => (app) => {
   app.set(name, () => new ClientClass(
     app.get('appConfiguration').get(configurationKey),
     app.get('http'),
     app.get('HTTPError')
   ));
 });
-/**
- * The service provider that once registered on the app container will set an instance of
- * `APIClient` as the `apiClient` service.
- * @example
- * // Register it on the container
- * container.register(apiClient);
- * // Getting access to the service instance
- * const apiClient = container.get('apiClient');
- * @type {Provider}
- */
-const apiClient = apiClientCustom();
 
 module.exports = {
   APIClient,
   apiClient,
-  apiClientCustom,
 };

--- a/src/services/api/index.js
+++ b/src/services/api/index.js
@@ -1,19 +1,18 @@
 const { apiClient } = require('./client');
 const { ensureBearerAuthentication } = require('./ensureBearerAuthentication');
-const { provider } = require('../../utils/wrappers');
-/**
- * A single service provider that once registered on the app container will take care of
- * registering the providers for the `apiClient`, 'ensureBearerAuthentication' and
- * `versionValidator` services.
- * @type {Provider}
- */
-const all = provider((app) => {
-  app.register(apiClient);
-  app.register(ensureBearerAuthentication);
-});
+const { providers } = require('../../utils/wrappers');
 
-module.exports = {
+/**
+ * The providers collection for the API services.
+ * @type {Provider}
+ * @property {Provider} apiClient
+ * The provider for {@link APIClient}.
+ * @property {Provider} ensureBearerAuthentication
+ * The provider for {@link EnsureBearerAuthentication}.
+ */
+const apiServices = providers({
   apiClient,
   ensureBearerAuthentication,
-  all,
-};
+});
+
+module.exports = apiServices;

--- a/src/services/api/index.js
+++ b/src/services/api/index.js
@@ -1,4 +1,4 @@
-const { apiClient, apiClientCustom } = require('./client');
+const { apiClient } = require('./client');
 const { ensureBearerAuthentication } = require('./ensureBearerAuthentication');
 const { provider } = require('../../utils/wrappers');
 /**
@@ -14,7 +14,6 @@ const all = provider((app) => {
 
 module.exports = {
   apiClient,
-  apiClientCustom,
   ensureBearerAuthentication,
   all,
 };

--- a/src/services/common/index.js
+++ b/src/services/common/index.js
@@ -1,21 +1,18 @@
 const { appError } = require('./appError');
 const { httpError } = require('./httpError');
 const { sendFileProvider } = require('./sendFile');
-const { provider } = require('../../utils/wrappers');
+const { providers } = require('../../utils/wrappers');
 /**
- * A single service provider that once registered on the app container will take care of
- * registering the providers for the `appError` and `sendFileProvider` services.
+ * The providers collection for the common services.
  * @type {Provider}
+ * @property {Provider} appError  The provider for {@link AppError}.
+ * @property {Provider} httpError The provider for {@link HTTPError}.
+ * @property {Provider} sendFile  The provider for {@link SendFile}.
  */
-const all = provider((app) => {
-  app.register(appError);
-  app.register(httpError);
-  app.register(sendFileProvider);
-});
-
-module.exports = {
+const commonServices = providers({
   appError,
   httpError,
   sendFile: sendFileProvider,
-  all,
-};
+});
+
+module.exports = commonServices;

--- a/src/services/html/htmlGenerator.js
+++ b/src/services/html/htmlGenerator.js
@@ -1,6 +1,6 @@
 const ObjectUtils = require('wootils/shared/objectUtils');
 const { deferred } = require('wootils/shared');
-const { provider } = require('../../utils/wrappers');
+const { providerCreator } = require('../../utils/wrappers');
 /**
  * @typedef {Object} HTMLGeneratorOptions The options to customize the an `HTMLGenerator` service.
  * @property {string}  [template='index.tpl.html']                 The name of the file it should
@@ -288,22 +288,21 @@ class HTMLGenerator {
   }
 }
 /**
- * Generates an `HTMLGenerator` service provider with customized options and that automatically
- * hooks itself to the `after-start` event of the app server in order to trigger the generation of
- * the html file when the server starts.
+ * A service that hooks itself to the `after-start` event of the app server in order to trigger
+ * the generation an the html file when the server starts.
+ * @type {ProviderCreator}
  * @param {HTMLGeneratorOptions}  [options={}]                  Options to customize the service.
  * @param {string}                [serviceName='htmlGenerator'] The name of the service that will
  *                                                              be register into the app.
  * @param {?string}               [valuesServiceName=null]      The name of a service used to read
  *                                                              the values that will be injected in
  *                                                              the generated file.
- * @return {Provider}
  */
-const htmlGeneratorCustom = (
+const htmlGenerator = providerCreator((
   options = {},
   serviceName = 'htmlGenerator',
   valuesServiceName = null
-) => provider((app) => {
+) => (app) => {
   app.set(serviceName, () => {
     let valuesService = null;
     if (valuesServiceName) {
@@ -322,22 +321,8 @@ const htmlGeneratorCustom = (
   app.get('events')
   .once('after-start', () => app.get(serviceName).generateHTML());
 });
-/**
- * The service provider that once registered on the app container will set an instance of
- * `HTMLGenerator` as the `htmlGenerator` service. It also hooks itself to the `after-start`
- * event of the app server in order to trigger the generation of
- * the html file when the server starts.
- * @example
- * // Register it on the container
- * container.register(htmlGenerator);
- * // Getting access to the service instance
- * const htmlGenerator = container.get('htmlGenerator');
- * @type {Provider}
- */
-const htmlGenerator = htmlGeneratorCustom();
 
 module.exports = {
   HTMLGenerator,
   htmlGenerator,
-  htmlGeneratorCustom,
 };

--- a/src/services/html/index.js
+++ b/src/services/html/index.js
@@ -1,6 +1,5 @@
-const { htmlGenerator, htmlGeneratorCustom } = require('./htmlGenerator');
+const { htmlGenerator } = require('./htmlGenerator');
 
 module.exports = {
   htmlGenerator,
-  htmlGeneratorCustom,
 };

--- a/src/services/http/index.js
+++ b/src/services/http/index.js
@@ -1,18 +1,15 @@
 const { http } = require('./http');
 const { responsesBuilder } = require('./responsesBuilder');
-const { provider } = require('../../utils/wrappers');
+const { providers } = require('../../utils/wrappers');
 /**
- * A single service provider that once registered on the app container will take care of
- * registering the providers for the `http` and 'responsesBuilder' services.
+ * The providers collection for the HTTP services.
  * @type {Provider}
+ * @property {Provider} http             The provider for {@link HTTP}.
+ * @property {Provider} responsesBuilder The provider for {@link ResponsesBuilder}.
  */
-const all = provider((app) => {
-  app.register(http);
-  app.register(responsesBuilder);
-});
-
-module.exports = {
+const httpServices = providers({
   http,
   responsesBuilder,
-  all,
-};
+});
+
+module.exports = httpServices;

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -55,36 +55,8 @@
  */
 
 /**
- * @typedef {function(err:?Error)} ExpressNext A function to call the next middleware. If an
- *                                            argument is specified, it will be handled as an error
- *                                            and sent to the `errorHandler` service.
- */
-
-/**
- * @typedef {Object} Provider An object that when registered on Jimpex will take care of setting up
- *                            services and/or configuring the app.
- *                            The method Jimpex uses to register a provider is `register(provider)`
- *                            and is inherit from Jimple.
- * @property {function(app:Jimpex)} register The method that gets called by Jimpex when registering
- *                                           the provider.
- */
-
-/**
- * @typedef {Object} Controller An object that when mounted on Jimpex will return a list of routes
- *                              to handle an specific point.
- *                              The method Jimpex uses to mount a controller is
- *                              `mount(point, controller)`.
- * @property {function(app:Jimpex,point:String):Array} connect The method that gets called by
- *                                                             Jimpex when the controller is
- *                                                             mounted. It should return a list
- *                                                             of routes.
- */
-
-/**
- * @typedef {Object} Middleware An object that when mounted on Jimpex will return an Express
- *                              middleware for the app to use.
- *                              The method Jimpex uses to mount a controller is `use(middleware)`.
- * @property {function(app:Jimpex):?ExpressMiddleware} connect The method that gets called by Jimpex
- *                                                             when the middleware is mounted. It
- *                                                             should return an Express middleware.
+ * @typdef {function} ExpressNext
+ * @description A function to call the next middleware. If an argument is specified, it will be
+ *              handled as an error and sent to the `errorHandler` service.
+ * @param {?Error} error The error to sent to the error handler.
  */

--- a/src/utils/wrappers.js
+++ b/src/utils/wrappers.js
@@ -1,23 +1,215 @@
-const { provider } = require('jimple');
 /**
- * Generates a controller for the app container to mount.
- * @param {function(app:Jimpex):Array} connect A function that will be called the moment the app
- *                                             mounts the controller. It should return a list
- *                                             of routes.
+ * @typedef {Object} Provider
+ * @description An object that when registered on Jimpex will take care of setting up services
+ *              and/or configuring the app. The method Jimpex uses to register a provider is
+ *              {@link Jimpex#register} and is inherit from {@link Jimple}.
+ * @property {ProviderRegistrationCallback} register The function Jimpex calls when registering
+ *                                                   the provider.
+ */
+
+/**
+ * @typedef {function} ProviderCreator
+ * @description A special kind of {@link Provider} because it can be used with
+ *              {@link Jimpex#register} as a regular provider, or it can be called as a function
+ *              with custom paramters in order to obtain a "configured {@link Provider}"
+ * @return {Provider}
+ */
+
+/**
+ * @typedef {function} ProviderRegistrationCallback
+ * @description The function called by the app container in order to register a service provider.
+ * @param {Jimpex} app The instance of the app container.
+ */
+
+/**
+ * @typedef {function} ProviderCreatorCallback
+ * @description A function called in order to generate a {@link Provider}. They usually have
+ *              different options that will be sent to the service registration.
+ * @return {ProviderRegistrationCallback}
+ */
+
+/**
+ * @typedef {Object} Controller
+ * @description An object that when mounted on Jimpex will take care of handling a list of specific
+ *              routes. The method Jimpex uses to mount a controller is {@link Jimpex#mount}.
+ * @property {ControllerMountCallback} connect The function Jimpex calls when mounting the
+ *                                             controller.
+ */
+
+/**
+ * @typedef {function} ControllerCreator
+ * @description A special kind of {@link Controller} because it can be used with
+ *              {@link Jimpex#mount} as a regular controller, or it can be called as a function
+ *              with custom paramters in order to obtain a "configured {@link Controller}"
  * @return {Controller}
  */
-const controller = (connect) => ({ connect });
+
 /**
- * Generates a middleware for the app container to use.
+ * @typedef {function} ControllerMountCallback
+ * @description The function called by the app container in order to mount a routes controller.
+ * @param {Jimpex} app   The instance of the app container.
+ * @param {string} point The point where the controller will be mounted.
+ * @return {Array} The list of routes the controller will manage.
+ */
+
+/**
+ * @typedef {function} ControllerCreatorCallback
+ * @description A function called in order to generate a {@link Controller}. They usually have
+ *              different options that will be sent to the controller creation.
+ * @return {ControllerMountCallback}
+ */
+
+/**
+ * @typedef {Object} Middleware
+ * @description An object that when mounted on Jimpex add an {@link ExpressMiddleware} to the app.
+ *              The method Jimpex uses to mount a middleware is {@link Jimpex#use}.
+ * @property {MiddlewareUseCallback} connect The function Jimpex calls when mounting the
+ *                                           middleware.
+ */
+
+/**
+ * @typedef {function} MiddlewareCreator
+ * @description A special kind of {@link Middleware} because it can be used with
+ *              {@link Jimpex#use} as a regular middleware, or it can be called as a function
+ *              with custom paramters in order to obtain a "configured {@link Middleware}"
+ * @return {Middleware}
+ */
+
+/**
+ * @typedef {function} MiddlewareUseCallback
+ * @description The function called by the app container in order to use a middleware.
+ * @param {Jimpex} app The instance of the app container.
+ * @return {?ExpressMiddleware} A middleware for Express to use. It can also return `null` in case
+ *                              there's a reason for the middleware not to be active.
+ */
+
+/**
+ * @typedef {function} MiddlewareCreatorCallback
+ * @description A function called in order to generate a {@link Middleware}. They usually have
+ *              different options that will be sent to the middleware creation.
+ * @return {MiddlewareUseCallback}
+ */
+
+/**
+ * This is a helper the wrappers use in order to create an object by placing a given function
+ * on an specific key.
+ * @param {string}   key The key in which the function will be placed.
+ * @param {function} fn  The function to insert in the object.
+ * @return {Object}
+ * @ignore
+ */
+const resource = (key, fn) => ({
+  [key]: fn,
+});
+/**
+ * Similar to `resource`, this helper creates an "object" and places a given function on an
+ * specify key. The difference is that instead of being an actual object what gets created, it's
+ * another function, then a proxy is added to that function in order to intercept the `key`
+ * property and return the result of the function.
+ *
+ * This is kind of hard to explain, so let's compare it with `resource` and use a proper example:
+ * - `resource`: (key, fn) => ({ [key]: fn })
+ * - `resourceCreator`: ((key, creatorFn) => creatorFn(...) => fn)[key]: creatorFn()
+ *
+ * While `resource` is meant to create objects with a resource function, this is meant to create
+ * those resource functions by sending them "optional paramters", and they are optionals because
+ * if you access the `key` property, it would be the same as calling the `creatorFn` without
+ * paramters.
+ * @param {string}   key       The key in which the creator function will be placed in case it's
+ *                             used without parameters; and also the key in which the result
+ *                             function from the creator will be placed if called with parameters.
+ * @param {function} creatorFn The function that generates the "resource function".
+ * @return {function}
+ * @ignore
+ */
+const resourceCreator = (key, creatorFn) => new Proxy(
+  (...args) => resource(key, creatorFn(...args)),
+  {
+    resource: null,
+    get(target, property) {
+      let result;
+      if (property === key) {
+        if (this.resource === null) {
+          this.resource = creatorFn();
+        }
+        result = this.resource;
+      } else {
+        result = target[property];
+      }
+
+      return result;
+    },
+  }
+);
+/**
+ * Generates a service provider for the app container.
+ * @param {ProviderRegistrationCallback} registerFn A function that will be called the moment the
+ *                                                  app registers the provider.
+ * @return {Provider}
+ */
+const provider = (registerFn) => resource('register', registerFn);
+/**
+ * Generates a configurable service provider for the app container. It's configurable because
+ * the creator, instead of just being sent to the container to register, it can also be called
+ * as a function with custom parameters the service can receive.
+ * @example
+ * const myService = providerCreator((options) => (app) => {
+ *   app.set('myService', () => new MyService(options));
+ * });
+ * @param {ProviderCreatorCallback} creatorFn The function that generates the provider.
+ * @return {ProviderCreator}
+ */
+const providerCreator = (creatorFn) => resourceCreator('register', creatorFn);
+/**
+ * Generates a routes controller for the app container to mount.
+ * @param {ControllerMountCallback} connect A function that will be called the moment the app
+ *                                          mounts the controller. It should return a list of
+ *                                          routes.
+ * @return {Controller}
+ */
+const controller = (connectFn) => resource('connect', connectFn);
+/**
+ * Generates a configurable routes controller for the app to mount. It's configurable because
+ * the creator, instead of just being sent to the container to mount, it can also be called
+ * as a function with custom parameters the controller can receive.
+ * @example
+ * const myController = controllerCreator((options) => (app) => {
+ *   const router = app.get('router');
+ *   const ctrl = new MyController(options);
+ *   return [router.get('...', ctrl.doSomething())];
+ * });
+ * @param {ProviderCreatorCallback} creatorFn The function that generates the provider.
+ * @return {ProviderCreator}
+ */
+const controllerCreator = (creatorFn) => resourceCreator('connect', creatorFn);
+/**
+ * Generates a middleware for the app to use.
  * @param {function(app:Jimpex):?ExpressMiddleware} connect A function that will be called the
  *                                                          moment the app mounts the middleware.
  *                                                          It should return an Express middleware.
  * @return {Middleware}
  */
-const middleware = (connect) => ({ connect });
+const middleware = (connectFn) => resource('connect', connectFn);
+/**
+ * Generates a configurable middleware for the app to use. It's configurable because the creator,
+ * instead of just being sent to the container to use, it can also be called as a function with
+ * custom parameters the middleware can receive.
+ * @example
+ * const myMiddleware = middlewareCreator((options) => (app) => (
+ *   options.enabled ?
+ *     (req, res, next) => {} :
+ *     null
+ * ));
+ * @param {ProviderCreatorCallback} creatorFn The function that generates the provider.
+ * @return {ProviderCreator}
+ */
+const middlewareCreator = (creatorFn) => resourceCreator('connect', creatorFn);
 
 module.exports = {
   provider,
+  providerCreator,
   controller,
+  controllerCreator,
   middleware,
+  middlewareCreator,
 };

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -11,9 +11,9 @@ jest.mock('compression', () => compressionMock);
 jest.mock('multer', () => multerMock);
 jest.mock('body-parser', () => bodyParserMock);
 jest.mock('wootils/node/providers', () => wootilsMock);
-jest.mock('/src/services/api', () => ({ all: 'apiServices' }));
-jest.mock('/src/services/common', () => ({ all: 'commonServices' }));
-jest.mock('/src/services/http', () => ({ all: 'httpServices' }));
+jest.mock('/src/services/api', () => 'apiServices');
+jest.mock('/src/services/common', () => 'commonServices');
+jest.mock('/src/services/http', () => 'httpServices');
 jest.unmock('/src/app/index');
 
 const path = require('path');

--- a/tests/controllers/common/configuration.test.js
+++ b/tests/controllers/common/configuration.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/controllers/common/configuration');
 

--- a/tests/controllers/common/health.test.js
+++ b/tests/controllers/common/health.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/controllers/common/health');
 

--- a/tests/controllers/common/rootStatics.test.js
+++ b/tests/controllers/common/rootStatics.test.js
@@ -4,7 +4,7 @@ jest.unmock('/src/controllers/common/rootStatics');
 require('jasmine-expect');
 const {
   RootStaticsController,
-  rootStaticsControllerCustom,
+  rootStaticsController,
 } = require('/src/controllers/common/rootStatics');
 
 describe('controllers/common:rootStatics', () => {
@@ -128,6 +128,33 @@ describe('controllers/common:rootStatics', () => {
 
   it('should include a controller shorthand to return its routes', () => {
     // Given
+    const files = ['index.html', 'favicon.ico'];
+    const services = {
+      router: {
+        all: jest.fn((route, middleware) => [`all:${route}`, middleware.toString()]),
+      },
+    };
+    const app = {
+      get: jest.fn((service) => (services[service] || service)),
+    };
+    let routes = null;
+    let toCompare = null;
+    const expectedGets = ['router', 'sendFile'];
+    // When
+    routes = rootStaticsController.connect(app);
+    toCompare = new RootStaticsController('sendFile');
+    // Then
+    expect(routes).toEqual(files.map((file) => (
+      [`all:/${file}`, toCompare.serveFile(file).toString()]
+    )));
+    expect(app.get).toHaveBeenCalledTimes(expectedGets.length);
+    expectedGets.forEach((service) => {
+      expect(app.get).toHaveBeenCalledWith(service);
+    });
+  });
+
+  it('should include a controller creator shorthand to configure the files', () => {
+    // Given
     const file = 'index.html';
     const services = {
       router: {
@@ -141,7 +168,7 @@ describe('controllers/common:rootStatics', () => {
     let toCompare = null;
     const expectedGets = ['router', 'sendFile'];
     // When
-    routes = rootStaticsControllerCustom([file]).connect(app);
+    routes = rootStaticsController([file]).connect(app);
     toCompare = new RootStaticsController('sendFile', [file]);
     // Then
     expect(routes).toEqual([

--- a/tests/controllers/common/rootStatics.test.js
+++ b/tests/controllers/common/rootStatics.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/controllers/common/rootStatics');
 

--- a/tests/controllers/index.test.js
+++ b/tests/controllers/index.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.mock('/src/utils/wrappers', () => ({
   controller: (connect) => connect,
 }));

--- a/tests/controllers/index.test.js
+++ b/tests/controllers/index.test.js
@@ -1,6 +1,4 @@
-jest.mock('/src/utils/wrappers', () => ({
-  controller: (connect) => connect,
-}));
+jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/controllers');
 
 require('jasmine-expect');
@@ -16,8 +14,6 @@ describe('controllers', () => {
     expect(Object.keys(controllers).length).toBe(knownControllers.length);
     knownControllers.forEach((name) => {
       expect(controllers[name]).toBeObject();
-      const modules = Object.keys(controllers[name]);
-      modules.forEach((mod) => expect(controllers[name][mod]).toBeFunction());
     });
   });
 });

--- a/tests/middlewares/common/errorHandler.test.js
+++ b/tests/middlewares/common/errorHandler.test.js
@@ -6,7 +6,6 @@ const statuses = require('statuses');
 const {
   ErrorHandler,
   errorHandler,
-  errorHandlerCustom,
 } = require('/src/middlewares/common/errorHandler');
 
 describe('middlewares/common:errorHandler', () => {
@@ -291,7 +290,7 @@ describe('middlewares/common:errorHandler', () => {
     expect(appConfiguration.get).toHaveBeenCalledWith('debug');
   });
 
-  it('should include a middleware generator shorthand', () => {
+  it('should include a middleware creator shorthand to modify its options', () => {
     // Given
     const appConfiguration = {
       debug: {
@@ -314,7 +313,7 @@ describe('middlewares/common:errorHandler', () => {
       'AppError',
     ];
     // When
-    middleware = errorHandlerCustom().connect(app);
+    middleware = errorHandler().connect(app);
     toCompare = new ErrorHandler(
       'appLogger',
       'responsesBuilder',

--- a/tests/middlewares/common/errorHandler.test.js
+++ b/tests/middlewares/common/errorHandler.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/middlewares/common/errorHandler');
 

--- a/tests/middlewares/common/forceHTTPS.test.js
+++ b/tests/middlewares/common/forceHTTPS.test.js
@@ -4,7 +4,7 @@ jest.unmock('/src/middlewares/common/forceHTTPS');
 require('jasmine-expect');
 const {
   ForceHTTPS,
-  forceHTTPSCustom,
+  forceHTTPS,
 } = require('/src/middlewares/common/forceHTTPS');
 
 describe('middlewares/common:forceHTTPS', () => {
@@ -135,7 +135,7 @@ describe('middlewares/common:forceHTTPS', () => {
       'appConfiguration',
     ];
     // When
-    middleware = forceHTTPSCustom().connect(app);
+    middleware = forceHTTPS.connect(app);
     toCompare = new ForceHTTPS();
     // Then
     expect(middleware.toString()).toEqual(toCompare.middleware().toString());
@@ -164,7 +164,7 @@ describe('middlewares/common:forceHTTPS', () => {
       'appConfiguration',
     ];
     // When
-    middleware = forceHTTPSCustom().connect(app);
+    middleware = forceHTTPS().connect(app);
     // Then
     expect(middleware).toBeNull();
     expect(app.get).toHaveBeenCalledTimes(expectedGets.length);

--- a/tests/middlewares/common/forceHTTPS.test.js
+++ b/tests/middlewares/common/forceHTTPS.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/middlewares/common/forceHTTPS');
 

--- a/tests/middlewares/html/fastHTML.test.js
+++ b/tests/middlewares/html/fastHTML.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/middlewares/html/fastHTML');
 

--- a/tests/middlewares/html/fastHTML.test.js
+++ b/tests/middlewares/html/fastHTML.test.js
@@ -4,7 +4,7 @@ jest.unmock('/src/middlewares/html/fastHTML');
 require('jasmine-expect');
 const {
   FastHTML,
-  fastHTMLCustom,
+  fastHTML,
 } = require('/src/middlewares/html/fastHTML');
 
 describe('middlewares/html:fastHTML', () => {
@@ -171,7 +171,36 @@ describe('middlewares/html:fastHTML', () => {
       'sendFile',
     ];
     // When
-    middleware = fastHTMLCustom().connect(app);
+    middleware = fastHTML.connect(app);
+    toCompare = new FastHTML();
+    // Then
+    expect(middleware.toString()).toEqual(toCompare.middleware().toString());
+    expect(app.get).toHaveBeenCalledTimes(expectedGets.length);
+    expectedGets.forEach((service) => {
+      expect(app.get).toHaveBeenCalledWith(service);
+    });
+  });
+
+  it('should include a middleware creator shorthand to configure its options', () => {
+    // Given
+    const services = {};
+    const app = {
+      get: jest.fn((service) => {
+        if (service === 'htmlGenerator') {
+          throw Error();
+        }
+
+        return services[service] || service;
+      }),
+    };
+    let middleware = null;
+    let toCompare = null;
+    const expectedGets = [
+      'htmlGenerator',
+      'sendFile',
+    ];
+    // When
+    middleware = fastHTML().connect(app);
     toCompare = new FastHTML();
     // Then
     expect(middleware.toString()).toEqual(toCompare.middleware().toString());

--- a/tests/middlewares/html/showHTML.test.js
+++ b/tests/middlewares/html/showHTML.test.js
@@ -4,7 +4,7 @@ jest.unmock('/src/middlewares/html/showHTML');
 require('jasmine-expect');
 const {
   ShowHTML,
-  showHTMLCustom,
+  showHTML,
 } = require('/src/middlewares/html/showHTML');
 
 describe('middlewares/html:showHTML', () => {
@@ -144,7 +144,7 @@ describe('middlewares/html:showHTML', () => {
       'sendFile',
     ];
     // When
-    middleware = showHTMLCustom().connect(app);
+    middleware = showHTML.connect(app);
     toCompare = new ShowHTML();
     // Then
     expect(middleware.toString()).toEqual(toCompare.middleware().toString());
@@ -152,5 +152,36 @@ describe('middlewares/html:showHTML', () => {
     expectedGets.forEach((service) => {
       expect(app.get).toHaveBeenCalledWith(service);
     });
+  });
+
+  it('should include a middleware creator shorthand to configure its options', () => {
+    // Given
+    const htmlGeneratorServiceName = 'someCustomService';
+    const htmlGeneratorService = {
+      getFile: jest.fn(() => ''),
+    };
+    const app = {
+      get: jest.fn((service) => (
+        service === htmlGeneratorServiceName ?
+          htmlGeneratorService :
+          service
+      )),
+    };
+    let middleware = null;
+    let toCompare = null;
+    const expectedGets = [
+      htmlGeneratorServiceName,
+      'sendFile',
+    ];
+    // When
+    middleware = showHTML('some-file', htmlGeneratorServiceName).connect(app);
+    toCompare = new ShowHTML();
+    // Then
+    expect(middleware.toString()).toEqual(toCompare.middleware().toString());
+    expect(app.get).toHaveBeenCalledTimes(expectedGets.length);
+    expectedGets.forEach((service) => {
+      expect(app.get).toHaveBeenCalledWith(service);
+    });
+    expect(htmlGeneratorService.getFile).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/middlewares/html/showHTML.test.js
+++ b/tests/middlewares/html/showHTML.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/middlewares/html/showHTML');
 

--- a/tests/middlewares/index.test.js
+++ b/tests/middlewares/index.test.js
@@ -1,6 +1,4 @@
-jest.mock('/src/utils/wrappers', () => ({
-  middleware: (connect) => connect,
-}));
+jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/middlewares');
 
 require('jasmine-expect');
@@ -18,8 +16,6 @@ describe('middlewares', () => {
     expect(Object.keys(middlewares).length).toBe(knownMiddlewares.length);
     knownMiddlewares.forEach((name) => {
       expect(middlewares[name]).toBeObject();
-      const modules = Object.keys(middlewares[name]);
-      modules.forEach((mod) => expect(middlewares[name][mod]).toBeFunction());
     });
   });
 });

--- a/tests/middlewares/index.test.js
+++ b/tests/middlewares/index.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.mock('/src/utils/wrappers', () => ({
   middleware: (connect) => connect,
 }));

--- a/tests/middlewares/utils/versionValidator.test.js
+++ b/tests/middlewares/utils/versionValidator.test.js
@@ -6,7 +6,6 @@ const statuses = require('statuses');
 const {
   VersionValidator,
   versionValidator,
-  versionValidatorCustom,
 } = require('/src/middlewares/utils/versionValidator');
 
 describe('services/api:versionValidator', () => {
@@ -295,7 +294,7 @@ describe('services/api:versionValidator', () => {
         'AppError',
       ];
       // When
-      sut = versionValidatorCustom().connect(app);
+      sut = versionValidator().connect(app);
       toCompare = new VersionValidator('25.09');
       // Then
       expect(sut.toString()).toEqual(toCompare.middleware().toString());

--- a/tests/middlewares/utils/versionValidator.test.js
+++ b/tests/middlewares/utils/versionValidator.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/middlewares/utils/versionValidator');
 

--- a/tests/services/api/client.test.js
+++ b/tests/services/api/client.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/api/client');
 

--- a/tests/services/api/client.test.js
+++ b/tests/services/api/client.test.js
@@ -99,7 +99,7 @@ describe('services/api:client', () => {
     let serviceName = null;
     let serviceFn = null;
     // When
-    apiClientCustom(name, configurationKey, ClientClass)(app);
+    apiClientCustom(name, configurationKey, ClientClass).register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     sut = serviceFn();
     // Then

--- a/tests/services/api/client.test.js
+++ b/tests/services/api/client.test.js
@@ -4,7 +4,7 @@ jest.unmock('/src/services/api/client');
 require('jasmine-expect');
 const {
   APIClient,
-  apiClientCustom,
+  apiClient,
 } = require('/src/services/api/client');
 const APIClientBase = require('wootils/shared/apiClient');
 
@@ -70,6 +70,48 @@ describe('services/api:client', () => {
   it('should include a provider for the DIC', () => {
     // Given
     const appConfiguration = {
+      api: {
+        url: 'my-api',
+        endpoints: {
+          info: 'api-info',
+        },
+      },
+      get: jest.fn(() => appConfiguration.api),
+    };
+    const http = {
+      fetch: 'fetch',
+    };
+    const services = {
+      appConfiguration,
+      http,
+    };
+    const app = {
+      set: jest.fn(),
+      get: jest.fn((service) => (services[service] || service)),
+    };
+    let sut = null;
+    let serviceName = null;
+    let serviceFn = null;
+    // When
+    apiClient.register(app);
+    [[serviceName, serviceFn]] = app.set.mock.calls;
+    sut = serviceFn();
+    // Then
+    expect(sut).toBeInstanceOf(APIClientBase);
+    expect(sut).toBeInstanceOf(APIClient);
+    expect(sut.apiConfig).toBe(appConfiguration.api);
+    expect(sut.url).toBe(appConfiguration.api.url);
+    expect(sut.endpoints).toEqual(appConfiguration.api.endpoints);
+    expect(sut.HTTPError).toBe('HTTPError');
+    expect(sut.fetchClient).toBe(http.fetch);
+    expect(serviceName).toBe('apiClient');
+    expect(appConfiguration.get).toHaveBeenCalledTimes(1);
+    expect(appConfiguration.get).toHaveBeenCalledWith('api');
+  });
+
+  it('should include a provider creactor to configure its options', () => {
+    // Given
+    const appConfiguration = {
       apiConfig: {
         url: 'my-api',
         endpoints: {
@@ -96,7 +138,7 @@ describe('services/api:client', () => {
     let serviceName = null;
     let serviceFn = null;
     // When
-    apiClientCustom(name, configurationKey, ClientClass).register(app);
+    apiClient(name, configurationKey, ClientClass).register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     sut = serviceFn();
     // Then

--- a/tests/services/api/ensureBearerAuthentication.test.js
+++ b/tests/services/api/ensureBearerAuthentication.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/api/ensureBearerAuthentication');
 
@@ -113,7 +110,7 @@ describe('services/api:ensureBearerAuthentication', () => {
     let toCompare = null;
     // When
     toCompare = new EnsureBearerAuthentication('AppError');
-    ensureBearerAuthentication(app);
+    ensureBearerAuthentication.register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     sut = serviceFn();
     // Then

--- a/tests/services/api/index.test.js
+++ b/tests/services/api/index.test.js
@@ -14,6 +14,7 @@ describe('services:api', () => {
       apiClient: expect.any(Function),
       ensureBearerAuthentication: {
         register: expect.any(Function),
+        provider: true,
       },
     };
     const expectedServicesNames = Object.keys(expectedServices);

--- a/tests/services/api/index.test.js
+++ b/tests/services/api/index.test.js
@@ -10,19 +10,20 @@ describe('services:api', () => {
     const app = {
       register: jest.fn(),
     };
-    const expectedServices = [
-      'apiClient',
-      'ensureBearerAuthentication',
-    ];
+    const expectedServices = {
+      apiClient: expect.any(Function),
+      ensureBearerAuthentication: {
+        register: expect.any(Function),
+      },
+    };
+    const expectedServicesNames = Object.keys(expectedServices);
     // When
     apiServices.all.register(app);
     // When/Then
-    expect(app.register).toHaveBeenCalledTimes(expectedServices.length);
-    expectedServices.forEach((service, index) => {
-      const registeredService = app.register.mock.calls[index][0];
-      expect(registeredService).toEqual({
-        register: expect.any(Function),
-      });
+    expect(app.register).toHaveBeenCalledTimes(expectedServicesNames.length);
+    expectedServicesNames.forEach((service, index) => {
+      const [registeredService] = app.register.mock.calls[index];
+      expect(registeredService).toEqual(expectedServices[service]);
       expect(registeredService.toString()).toBe(apiServices[service].toString());
     });
   });

--- a/tests/services/api/index.test.js
+++ b/tests/services/api/index.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/api');
 

--- a/tests/services/api/index.test.js
+++ b/tests/services/api/index.test.js
@@ -19,7 +19,7 @@ describe('services:api', () => {
     };
     const expectedServicesNames = Object.keys(expectedServices);
     // When
-    apiServices.all.register(app);
+    apiServices.register(app);
     // When/Then
     expect(app.register).toHaveBeenCalledTimes(expectedServicesNames.length);
     expectedServicesNames.forEach((service, index) => {

--- a/tests/services/api/index.test.js
+++ b/tests/services/api/index.test.js
@@ -18,12 +18,14 @@ describe('services:api', () => {
       'ensureBearerAuthentication',
     ];
     // When
-    apiServices.all(app);
+    apiServices.all.register(app);
     // When/Then
     expect(app.register).toHaveBeenCalledTimes(expectedServices.length);
     expectedServices.forEach((service, index) => {
       const registeredService = app.register.mock.calls[index][0];
-      expect(registeredService).toBeFunction();
+      expect(registeredService).toEqual({
+        register: expect.any(Function),
+      });
       expect(registeredService.toString()).toBe(apiServices[service].toString());
     });
   });

--- a/tests/services/common/appError.test.js
+++ b/tests/services/common/appError.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/common/appError');
 
@@ -77,7 +74,7 @@ describe('services/common:appError', () => {
       let serviceName = null;
       let serviceFn = null;
       // When
-      appError(app);
+      appError.register(app);
       [[serviceName, serviceFn]] = app.set.mock.calls;
       sut = serviceFn();
       // Then
@@ -99,7 +96,7 @@ describe('services/common:appError', () => {
       let serviceFn = null;
       let result = null;
       // When
-      appError(app);
+      appError.register(app);
       [, [serviceName, serviceFn]] = app.set.mock.calls;
       sut = serviceFn();
       result = sut(message, context);

--- a/tests/services/common/httpError.test.js
+++ b/tests/services/common/httpError.test.js
@@ -1,7 +1,5 @@
 const statuses = require('statuses');
-const JimpleMock = require('/tests/mocks/jimple.mock');
 
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/common/appError');
 jest.unmock('/src/services/common/httpError');
@@ -69,7 +67,7 @@ describe('services/common:httpError', () => {
       let serviceName = null;
       let serviceFn = null;
       // When
-      httpError(app);
+      httpError.register(app);
       [[serviceName, serviceFn]] = app.set.mock.calls;
       sut = serviceFn();
       // Then
@@ -88,7 +86,7 @@ describe('services/common:httpError', () => {
       let serviceFn = null;
       let result = null;
       // When
-      httpError(app);
+      httpError.register(app);
       [, [serviceName, serviceFn]] = app.set.mock.calls;
       sut = serviceFn();
       result = sut(message, statuses.conflict);

--- a/tests/services/common/index.test.js
+++ b/tests/services/common/index.test.js
@@ -16,7 +16,7 @@ describe('services:common', () => {
       'sendFile',
     ];
     // When
-    commonServices.all.register(app);
+    commonServices.register(app);
     // When/Then
     expect(app.register).toHaveBeenCalledTimes(expectedServices.length);
     expectedServices.forEach((service, index) => {

--- a/tests/services/common/index.test.js
+++ b/tests/services/common/index.test.js
@@ -23,6 +23,7 @@ describe('services:common', () => {
       const registeredService = app.register.mock.calls[index][0];
       expect(registeredService).toEqual({
         register: expect.any(Function),
+        provider: true,
       });
       expect(registeredService.toString()).toBe(commonServices[service].toString());
     });

--- a/tests/services/common/index.test.js
+++ b/tests/services/common/index.test.js
@@ -19,12 +19,14 @@ describe('services:common', () => {
       'sendFile',
     ];
     // When
-    commonServices.all(app);
+    commonServices.all.register(app);
     // When/Then
     expect(app.register).toHaveBeenCalledTimes(expectedServices.length);
     expectedServices.forEach((service, index) => {
       const registeredService = app.register.mock.calls[index][0];
-      expect(registeredService).toBeFunction();
+      expect(registeredService).toEqual({
+        register: expect.any(Function),
+      });
       expect(registeredService.toString()).toBe(commonServices[service].toString());
     });
   });

--- a/tests/services/common/index.test.js
+++ b/tests/services/common/index.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/common');
 

--- a/tests/services/common/sendFile.test.js
+++ b/tests/services/common/sendFile.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/common/sendFile');
 
@@ -116,7 +113,7 @@ describe('services/common:sendFile', () => {
     let serviceName = null;
     let serviceFn = null;
     // When
-    sendFileProvider(app);
+    sendFileProvider.register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     sut = serviceFn();
     // Then

--- a/tests/services/frontend/frontendFs.test.js
+++ b/tests/services/frontend/frontendFs.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.mock('fs-extra');
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/frontend/frontendFs');
@@ -126,7 +123,7 @@ describe('services/frontend:frontendFs', () => {
     let serviceName = null;
     let serviceFn = null;
     // When
-    frontendFs(app);
+    frontendFs.register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     sut = serviceFn();
     // Then

--- a/tests/services/html/htmlGenerator.test.js
+++ b/tests/services/html/htmlGenerator.test.js
@@ -7,7 +7,7 @@ jest.unmock('/src/services/html/htmlGenerator');
 require('jasmine-expect');
 const {
   HTMLGenerator,
-  htmlGeneratorCustom,
+  htmlGenerator,
 } = require('/src/services/html/htmlGenerator');
 
 describe('services/html:htmlGenerator', () => {
@@ -438,7 +438,7 @@ describe('services/html:htmlGenerator', () => {
     });
   });
 
-  it('should register the generator to be runned when the server starts', () => {
+  it('should register the generator to be executed when the server starts', () => {
     // Given
     const appConfiguration = {
       get: jest.fn(() => {}),
@@ -456,7 +456,7 @@ describe('services/html:htmlGenerator', () => {
       once: jest.fn(),
     };
     let sut = null;
-    const name = 'myHTMLGenerator';
+    const name = 'htmlGenerator';
     const services = {
       appConfiguration,
       appLogger,
@@ -472,7 +472,7 @@ describe('services/html:htmlGenerator', () => {
     let eventName = null;
     let eventFn = null;
     // When
-    htmlGeneratorCustom({}, name).register(app);
+    htmlGenerator.register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     [[eventName, eventFn]] = events.once.mock.calls;
     sut = serviceFn();
@@ -542,7 +542,7 @@ describe('services/html:htmlGenerator', () => {
     const expectedGets = Object.keys(services);
     const expectedEventName = 'after-start';
     // When
-    htmlGeneratorCustom({}, name, myValuesServiceName).register(app);
+    htmlGenerator({}, name, myValuesServiceName).register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     [[eventName, eventFn]] = events.once.mock.calls;
     sut = serviceFn();

--- a/tests/services/html/htmlGenerator.test.js
+++ b/tests/services/html/htmlGenerator.test.js
@@ -1,7 +1,5 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
 const wootilsMock = require('/tests/mocks/wootils.mock');
 
-jest.mock('jimple', () => JimpleMock);
 jest.mock('wootils/shared', () => wootilsMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/html/htmlGenerator');
@@ -474,7 +472,7 @@ describe('services/html:htmlGenerator', () => {
     let eventName = null;
     let eventFn = null;
     // When
-    htmlGeneratorCustom({}, name)(app);
+    htmlGeneratorCustom({}, name).register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     [[eventName, eventFn]] = events.once.mock.calls;
     sut = serviceFn();
@@ -544,7 +542,7 @@ describe('services/html:htmlGenerator', () => {
     const expectedGets = Object.keys(services);
     const expectedEventName = 'after-start';
     // When
-    htmlGeneratorCustom({}, name, myValuesServiceName)(app);
+    htmlGeneratorCustom({}, name, myValuesServiceName).register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     [[eventName, eventFn]] = events.once.mock.calls;
     sut = serviceFn();

--- a/tests/services/http/http.test.js
+++ b/tests/services/http/http.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.mock('node-fetch');
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/http/http');
@@ -46,7 +43,7 @@ describe('services/http:http', () => {
     let serviceName = null;
     let serviceFn = null;
     // When
-    http(app);
+    http.register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     sut = serviceFn();
     // Then
@@ -390,7 +387,7 @@ describe('services/http:http', () => {
     let serviceName = null;
     let serviceFn = null;
     // When
-    http(app);
+    http.register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     sut = serviceFn();
     // Then

--- a/tests/services/http/index.test.js
+++ b/tests/services/http/index.test.js
@@ -15,7 +15,7 @@ describe('services:http', () => {
       'responsesBuilder',
     ];
     // When
-    httpServices.all.register(app);
+    httpServices.register(app);
     // When/Then
     expect(app.register).toHaveBeenCalledTimes(expectedServices.length);
     expectedServices.forEach((service, index) => {

--- a/tests/services/http/index.test.js
+++ b/tests/services/http/index.test.js
@@ -22,6 +22,7 @@ describe('services:http', () => {
       const registeredService = app.register.mock.calls[index][0];
       expect(registeredService).toEqual({
         register: expect.any(Function),
+        provider: true,
       });
       expect(registeredService.toString()).toBe(httpServices[service].toString());
     });

--- a/tests/services/http/index.test.js
+++ b/tests/services/http/index.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/http');
 

--- a/tests/services/http/index.test.js
+++ b/tests/services/http/index.test.js
@@ -18,12 +18,14 @@ describe('services:http', () => {
       'responsesBuilder',
     ];
     // When
-    httpServices.all(app);
+    httpServices.all.register(app);
     // When/Then
     expect(app.register).toHaveBeenCalledTimes(expectedServices.length);
     expectedServices.forEach((service, index) => {
       const registeredService = app.register.mock.calls[index][0];
-      expect(registeredService).toBeFunction();
+      expect(registeredService).toEqual({
+        register: expect.any(Function),
+      });
       expect(registeredService.toString()).toBe(httpServices[service].toString());
     });
   });

--- a/tests/services/http/responsesBuilder.test.js
+++ b/tests/services/http/responsesBuilder.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/http/responsesBuilder');
 
@@ -188,7 +185,7 @@ describe('services/http:responsesBuilder', () => {
     let serviceName = null;
     let serviceFn = null;
     // When
-    responsesBuilder(app);
+    responsesBuilder.register(app);
     [[serviceName, serviceFn]] = app.set.mock.calls;
     sut = serviceFn();
     // Then

--- a/tests/services/index.test.js
+++ b/tests/services/index.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services');
 
@@ -21,8 +18,6 @@ describe('services', () => {
     expect(Object.keys(services).length).toBe(knownServices.length);
     knownServices.forEach((name) => {
       expect(services[name]).toBeObject();
-      const modules = Object.keys(services[name]);
-      modules.forEach((mod) => expect(services[name][mod]).toBeFunction());
     });
   });
 });

--- a/tests/utils/wrappers.test.js
+++ b/tests/utils/wrappers.test.js
@@ -6,36 +6,161 @@ jest.unmock('/src/utils/wrappers');
 require('jasmine-expect');
 const {
   provider,
+  providerCreator,
   controller,
+  controllerCreator,
   middleware,
+  middlewareCreator,
 } = require('/src/utils/wrappers');
 
 describe('utils/wrappers', () => {
-  it('should export the Jimple `provider` method', () => {
-    expect(provider).toBe(JimpleMock.provider);
-  });
+  describe('provider', () => {
+    it('should create a service provider with a `register` function', () => {
+      // Given
+      const serviceProvider = 'serviceProvider';
+      let result = null;
+      // When
+      result = provider(serviceProvider);
+      // Then
+      expect(result).toEqual({
+        register: serviceProvider,
+      });
+    });
 
-  it('should export a `controller` function that wraps a `connect` statement', () => {
-    // Given
-    const myController = 'my-controller';
-    let result = null;
-    // When
-    result = controller(myController);
-    // Then
-    expect(result).toEqual({
-      connect: myController,
+    it('should create a service provider creator', () => {
+      // Given
+      const serviceProvider = 'serviceProvider';
+      const creatorFn = jest.fn(() => serviceProvider);
+      const options = 'options';
+      let creator = null;
+      let result = null;
+      // When
+      creator = providerCreator(creatorFn);
+      result = creator(options);
+      // Then
+      expect(result).toEqual({
+        register: serviceProvider,
+      });
+      expect(creatorFn).toHaveBeenCalledTimes(1);
+      expect(creatorFn).toHaveBeenCalledWith(options);
+    });
+
+    it('should create a service provider creator that can be used without options', () => {
+      // Given
+      const serviceProvider = 'serviceProvider';
+      const creatorFn = jest.fn(() => serviceProvider);
+      let creator = null;
+      // When
+      creator = providerCreator(creatorFn);
+      // Then
+      expect(creator.register).toBe(serviceProvider);
+      expect(creator.anyOtherProp).toBeUndefined(); // to validate the getter.
+      expect(creatorFn).toHaveBeenCalledTimes(1);
+      expect(creatorFn).toHaveBeenCalledWith();
+    });
+
+    it('should create a service provider with default options just once', () => {
+      // Given
+      const serviceProvider = 'serviceProvider';
+      const creatorFn = jest.fn(() => serviceProvider);
+      let creator = null;
+      // When
+      creator = providerCreator(creatorFn);
+      // Then
+      expect(creator.register).toBe(serviceProvider);
+      expect(creator.register).toBe(serviceProvider); // this is the second trigger for the proxy.
+      expect(creatorFn).toHaveBeenCalledTimes(1);
+      expect(creatorFn).toHaveBeenCalledWith();
     });
   });
 
-  it('should export a `middleware` function that wraps a `connect` statement', () => {
-    // Given
-    const myMiddleware = 'my-middleware';
-    let result = null;
-    // When
-    result = middleware(myMiddleware);
-    // Then
-    expect(result).toEqual({
-      connect: myMiddleware,
+  describe('controller', () => {
+    it('should create a route controller with a `connect` function', () => {
+      // Given
+      const routeController = 'routeController';
+      let result = null;
+      // When
+      result = controller(routeController);
+      // Then
+      expect(result).toEqual({
+        connect: routeController,
+      });
+    });
+
+    it('should create a route controller creator', () => {
+      // Given
+      const routeController = 'routeController';
+      const creatorFn = jest.fn(() => routeController);
+      const options = 'options';
+      let creator = null;
+      let result = null;
+      // When
+      creator = controllerCreator(creatorFn);
+      result = creator(options);
+      // Then
+      expect(result).toEqual({
+        connect: routeController,
+      });
+      expect(creatorFn).toHaveBeenCalledTimes(1);
+      expect(creatorFn).toHaveBeenCalledWith(options);
+    });
+
+    it('should create a route controller creator that can be used without options', () => {
+      // Given
+      const routeController = 'routeController';
+      const creatorFn = jest.fn(() => routeController);
+      let creator = null;
+      // When
+      creator = controllerCreator(creatorFn);
+      // Then
+      expect(creator.connect).toBe(routeController);
+      expect(creatorFn).toHaveBeenCalledTimes(1);
+      expect(creatorFn).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('middleware', () => {
+    it('should create a route middleware with a `connect` function', () => {
+      // Given
+      const appMiddleware = 'appMiddleware';
+      let result = null;
+      // When
+      result = middleware(appMiddleware);
+      // Then
+      expect(result).toEqual({
+        connect: appMiddleware,
+      });
+    });
+
+    it('should create a route middleware creator', () => {
+      // Given
+      const appMiddleware = 'appMiddleware';
+      const creatorFn = jest.fn(() => appMiddleware);
+      const options = 'options';
+      let creator = null;
+      let result = null;
+      // When
+      creator = middlewareCreator(creatorFn);
+      result = creator(options);
+      // Then
+      expect(result).toEqual({
+        connect: appMiddleware,
+      });
+      expect(creatorFn).toHaveBeenCalledTimes(1);
+      expect(creatorFn).toHaveBeenCalledWith(options);
+    });
+
+    it('should create a route middleware creator that can be used without options', () => {
+      // Given
+      const appMiddleware = 'appMiddleware';
+      const creatorFn = jest.fn(() => appMiddleware);
+      let creator = null;
+      // When
+      creator = middlewareCreator(creatorFn);
+      // Then
+      expect(creator.connect).toBe(appMiddleware);
+      expect(creatorFn).toHaveBeenCalledTimes(1);
+      expect(creatorFn).toHaveBeenCalledWith();
     });
   });
 });

--- a/tests/utils/wrappers.test.js
+++ b/tests/utils/wrappers.test.js
@@ -4,6 +4,7 @@ require('jasmine-expect');
 const {
   provider,
   providerCreator,
+  providers,
   controller,
   controllerCreator,
   middleware,
@@ -71,6 +72,49 @@ describe('utils/wrappers', () => {
       expect(creator.register).toBe(serviceProvider); // this is the second trigger for the proxy.
       expect(creatorFn).toHaveBeenCalledTimes(1);
       expect(creatorFn).toHaveBeenCalledWith();
+    });
+
+    it('should create a providers collection', () => {
+      // Given
+      const serviceProviderOne = 'serviceProviderOne';
+      const serviceProviderTwo = 'serviceProviderTwo';
+      let collection = null;
+      // When
+      collection = providers({
+        one: serviceProviderOne,
+        two: serviceProviderTwo,
+      });
+      // Then
+      expect(collection.one).toBe(serviceProviderOne);
+      expect(collection.two).toBe(serviceProviderTwo);
+      expect(collection.three).toBeUndefined(); // to validate the getter.
+    });
+
+    it('should create a collection to register multiple providers at once', () => {
+      // Given
+      const app = {
+        register: jest.fn(),
+      };
+      const services = {
+        one: 'serviceProviderOne',
+        two: 'serviceProviderTwo',
+      };
+      const servicesNames = Object.keys(services);
+      let collection = null;
+      // When
+      collection = providers(services);
+      collection.register(app);
+      // Then
+      expect(app.register).toHaveBeenCalledTimes(servicesNames.length);
+      servicesNames.forEach((name) => {
+        expect(app.register).toHaveBeenCalledWith(services[name]);
+      });
+    });
+
+    it('should throw an error when trying to create a collection with invalid providers', () => {
+      // Given/When/Then
+      expect(() => providers({ providers: 'something' }))
+      .toThrow(/You can't create a collection with a providers called `register` or `providers`/i);
     });
   });
 

--- a/tests/utils/wrappers.test.js
+++ b/tests/utils/wrappers.test.js
@@ -1,6 +1,3 @@
-const JimpleMock = require('/tests/mocks/jimple.mock');
-
-jest.mock('jimple', () => JimpleMock);
 jest.unmock('/src/utils/wrappers');
 
 require('jasmine-expect');

--- a/tests/utils/wrappers.test.js
+++ b/tests/utils/wrappers.test.js
@@ -21,6 +21,7 @@ describe('utils/wrappers', () => {
       // Then
       expect(result).toEqual({
         register: serviceProvider,
+        provider: true,
       });
     });
 
@@ -37,6 +38,7 @@ describe('utils/wrappers', () => {
       // Then
       expect(result).toEqual({
         register: serviceProvider,
+        provider: true,
       });
       expect(creatorFn).toHaveBeenCalledTimes(1);
       expect(creatorFn).toHaveBeenCalledWith(options);
@@ -51,6 +53,7 @@ describe('utils/wrappers', () => {
       creator = providerCreator(creatorFn);
       // Then
       expect(creator.register).toBe(serviceProvider);
+      expect(creator.provider).toBeTrue();
       expect(creator.anyOtherProp).toBeUndefined(); // to validate the getter.
       expect(creatorFn).toHaveBeenCalledTimes(1);
       expect(creatorFn).toHaveBeenCalledWith();
@@ -81,6 +84,7 @@ describe('utils/wrappers', () => {
       // Then
       expect(result).toEqual({
         connect: routeController,
+        controller: true,
       });
     });
 
@@ -97,6 +101,7 @@ describe('utils/wrappers', () => {
       // Then
       expect(result).toEqual({
         connect: routeController,
+        controller: true,
       });
       expect(creatorFn).toHaveBeenCalledTimes(1);
       expect(creatorFn).toHaveBeenCalledWith(options);
@@ -111,6 +116,7 @@ describe('utils/wrappers', () => {
       creator = controllerCreator(creatorFn);
       // Then
       expect(creator.connect).toBe(routeController);
+      expect(creator.controller).toBeTrue();
       expect(creatorFn).toHaveBeenCalledTimes(1);
       expect(creatorFn).toHaveBeenCalledWith();
     });
@@ -126,6 +132,7 @@ describe('utils/wrappers', () => {
       // Then
       expect(result).toEqual({
         connect: appMiddleware,
+        middleware: true,
       });
     });
 
@@ -142,6 +149,7 @@ describe('utils/wrappers', () => {
       // Then
       expect(result).toEqual({
         connect: appMiddleware,
+        middleware: true,
       });
       expect(creatorFn).toHaveBeenCalledTimes(1);
       expect(creatorFn).toHaveBeenCalledWith(options);
@@ -156,6 +164,7 @@ describe('utils/wrappers', () => {
       creator = middlewareCreator(creatorFn);
       // Then
       expect(creator.connect).toBe(appMiddleware);
+      expect(creator.middleware).toBeTrue();
       expect(creatorFn).toHaveBeenCalledTimes(1);
       expect(creatorFn).toHaveBeenCalledWith();
     });


### PR DESCRIPTION
### What does this PR do?

This PR introduces "2" new concepts: controllers/middlewares/providers creators and providers collections.

The main problem to solve was regarding all the `[name]Custom` controllers/middlewares/providers (let's call them "resources"). I wanted a way to only have the resource once and configure it if needed, for example:

#### Creators

Instead of having `errorHandler` and `errorHandlerCustom`, I wanted something like this:

```js
this.register(errorHandler);
// or
this.register(errorHandler({ ... }));
```

So I "created" the "creators" (no pun intended). When defining a resource with customization options, instead of importing the resource wrapper, you import the resource "creator wrapper": `controllerCreator`, `middlewareCreator` and `providerCreator`.

The difference with the creator wrappers is that their parameter is not the callback that receives the container instance, but a function that receives the options and returns the regular callback, for example:

```js
const { providerCreator } = require('jimpex');

const myService = providerCreator((options) => (app) => {
  // ...
});
```

Now, what the creator wrapper returns is not an object, like the regular wrappers, but the actual "options function", with a `Proxy`. If the app tries to register the creator without calling it as a function, the proxy will automatically call the function give the app the returned callback as a regular wrapper.

If you fully understood the last paragraph, you probably already saw this coming, but in any case, this is **very important**: the `options` parameter, or whatever you define on the first function, **MUST be optional**, because if the implementation registers it as a regular resource, you won't get the parameter(s).

If you need the parameter(s) to be required, yes, create a different resource.

#### Providers collections

The collections are a way to define multiple service providers on a single group and being able to register all at once, or one by one, the implementation chooses.

This was made only for providers because it didn't make sense to do it for controllers and middlewares: you don't usually register a bunch of those at once, you set them on a specific order, or to specific routes.

The syntax is pretty simple:

```js
const { providers } = require('jimpex');

const collection = providers({
  providerOne: ...,
  providerTwo: ...,
});
```

And you can call `app.register` with the whole collection, or one by one:

```js
app.register(collection);
// or
app.register(collection.providerOne);
app.register(collection.providerTwo);
```

#### Breaking changes

- `controllers.rootStaticsControllerCustom` was removed. You can use `controllers.rootStaticsController` as a function (for now).
- `middlewares.common.errorHandlerCustom` was removed. You can use `middlewares.common.errorHandler` as a function.
- `middlewares.common.forceHTTPSCustom` was removed. You can use `middlewares.common.forceHTTPS` as a function.
- `middlewares.html.fastHTMLCustom` was removed. You can use `middlewares.html.fastHTML` as a function.
- `middlewares.html.showHTMLCustom` was removed. You can use `middlewares.html.showHTML` as a function.
- `middlewares.utils.versionValidatorCustom` was removed. You can use `middlewares.utils.versionValidator` as a function.
- `services.api.apiClientCustom` was removed. You can use `services.api.apiClient` as a function.
- `services.html.htmlGeneratorCustom` was removed. You can use `services.html.htmlGenerator` as a function.

### How should it be tested manually?

Remove all the customs you were using and replace then with the function call; and of course...

```bash
yarn test
# or
npm test
```