### PR TITLE
refactor(project): make every dependency injection protected

### DIFF
--- a/src/controllers/common/configuration.js
+++ b/src/controllers/common/configuration.js
@@ -12,22 +12,26 @@ class ConfigurationController {
     /**
      * A local reference for the `appConfiguration` service.
      * @type {AppConfiguration}
+     * @access protected
+     * @ignore
      */
-    this.appConfiguration = appConfiguration;
+    this._appConfiguration = appConfiguration;
     /**
      * A local reference for the `responsesBuilder` service.
      * @type {ResponsesBuilder}
+     * @access protected
+     * @ignore
      */
-    this.responsesBuilder = responsesBuilder;
+    this._responsesBuilder = responsesBuilder;
   }
   /**
    * Send a response with the current app configuration as a body.
    * @param {ExpressResponse} res The server response.
    */
   getConfigurationResponse(res) {
-    const name = this.appConfiguration.get('name');
-    const data = Object.assign({ name }, this.appConfiguration.getConfig());
-    return this.responsesBuilder.json(res, data);
+    const name = this._appConfiguration.get('name');
+    const data = Object.assign({ name }, this._appConfiguration.getConfig());
+    return this._responsesBuilder.json(res, data);
   }
   /**
    * Returns the middleware to show the current configuration.
@@ -44,9 +48,9 @@ class ConfigurationController {
    */
   switchConfiguration() {
     return (req, res, next) => {
-      if (this.appConfiguration.canSwitch()) {
+      if (this._appConfiguration.canSwitch()) {
         try {
-          this.appConfiguration.switch(req.params.name);
+          this._appConfiguration.switch(req.params.name);
           this.getConfigurationResponse(res);
         } catch (error) {
           next(error);

--- a/src/controllers/common/health.js
+++ b/src/controllers/common/health.js
@@ -15,13 +15,17 @@ class HealthController {
     /**
      * A local reference for the `appConfiguration` service.
      * @type {AppConfiguration}
+     * @access protected
+     * @ignore
      */
-    this.appConfiguration = appConfiguration;
+    this._appConfiguration = appConfiguration;
     /**
      * A local reference for the `responsesBuilder` service.
      * @type {ResponsesBuilder}
+     * @access protected
+     * @ignore
      */
-    this.responsesBuilder = responsesBuilder;
+    this._responsesBuilder = responsesBuilder;
   }
   /**
    * Returns the middleware that shows the health information.
@@ -32,8 +36,8 @@ class HealthController {
       const {
         name: configuration,
         version,
-      } = this.appConfiguration.get(['name', 'version']);
-      this.responsesBuilder.json(res, {
+      } = this._appConfiguration.get(['name', 'version']);
+      this._responsesBuilder.json(res, {
         isHealthy: true,
         status: statuses.ok,
         configuration,

--- a/src/controllers/common/rootStatics.js
+++ b/src/controllers/common/rootStatics.js
@@ -23,20 +23,24 @@ class RootStaticsController {
     /**
      * A local reference for the `sendFile` service.
      * @type {SendFile}
+     * @access protected
+     * @ignore
      */
-    this.sendFile = sendFile;
+    this._sendFile = sendFile;
     /**
-    * A dictionary with the file names as keys and information about the files as values.
-    * @type {Object}
-    */
-    this.files = this._parseFiles(files);
+     * A dictionary with the file names as keys and information about the files as  values.
+     * @type {Object}
+     * @access protected
+     * @ignore
+     */
+    this._files = this._parseFiles(files);
   }
   /**
    * Gets the list of files the service will serve.
    * @return {Array}
    */
   getFileEntries() {
-    return Object.keys(this.files);
+    return Object.keys(this._files);
   }
   /**
    * Generates a middleware to serve an specific file.
@@ -45,12 +49,12 @@ class RootStaticsController {
    * @throws {Error} If the file wasn't sent on the constructor.
    */
   serveFile(file) {
-    if (!this.files[file]) {
+    if (!this._files[file]) {
       throw new Error(`The required static file doesn't exist (${file})`);
     }
 
     return (req, res, next) => {
-      const item = this.files[file];
+      const item = this._files[file];
       const extension = item.output.split('.').pop().toLowerCase();
       const baseHeaders = { 'Content-Type': mime.getType(extension) };
       const headers = ObjectUtils.merge(baseHeaders, item.headers);
@@ -59,7 +63,7 @@ class RootStaticsController {
         res.setHeader(headerName, headers[headerName]);
       });
 
-      this.sendFile(res, item.output, next);
+      this._sendFile(res, item.output, next);
     };
   }
   /**

--- a/src/middlewares/common/errorHandler.js
+++ b/src/middlewares/common/errorHandler.js
@@ -47,23 +47,31 @@ class ErrorHandler {
     /**
      * A local reference for the `appLogger` service.
      * @type {Logger}
+     * @access protected
+     * @ignore
      */
-    this.appLogger = appLogger;
+    this._appLogger = appLogger;
     /**
      * A local reference for the `responsesBuilder` service.
      * @type {ResponsesBuilder}
+     * @access protected
+     * @ignore
      */
-    this.responsesBuilder = responsesBuilder;
+    this._responsesBuilder = responsesBuilder;
     /**
      * Whether or not to show unknown errors real messages.
      * @type {Boolean}
+     * @access protected
+     * @ignore
      */
-    this.showErrors = showErrors;
+    this._showErrors = showErrors;
     /**
      * A local reference for the class the app uses to generate errors.
      * @type {Class}
+     * @access protected
+     * @ignore
      */
-    this.AppError = AppError;
+    this._AppError = AppError;
     /**
      * These are the "settings" the middleware will use in order to display the errors.
      * @type {ErrorHandlerOptions}
@@ -96,9 +104,9 @@ class ErrorHandler {
         // Define the error response default status.
         let { status } = this._options.default;
         // Validate if the error is known or not.
-        const knownError = err instanceof this.AppError;
+        const knownError = err instanceof this._AppError;
         // If the `showErrors` flag is enabled or the error is a known error...
-        if (this.showErrors || knownError) {
+        if (this._showErrors || knownError) {
           // ...set the error real message on the response.
           data.message = err.message;
           // If the error type is known...
@@ -109,7 +117,7 @@ class ErrorHandler {
             status = err.status || statuses['Bad Request'];
           }
           // If the `showErrors` flag is enabled...
-          if (this.showErrors) {
+          if (this._showErrors) {
             // Get the error stack and format it into an `Array`.
             const stack = err.stack.split('\n').map((line) => line.trim());
             //  Add the stack to the response.
@@ -117,12 +125,12 @@ class ErrorHandler {
             // Remove the first item of the stack, since it's the same as the message.
             stack.splice(0, 1);
             // Log the error.
-            this.appLogger.error(`ERROR: ${err.message}`);
-            this.appLogger.info(stack);
+            this._appLogger.error(`ERROR: ${err.message}`);
+            this._appLogger.info(stack);
           }
         }
         // Send the response.
-        this.responsesBuilder.json(res, data, status);
+        this._responsesBuilder.json(res, data, status);
       } else {
         // ...otherwise, move to the next middleware.
         next();

--- a/src/middlewares/common/forceHTTPS.js
+++ b/src/middlewares/common/forceHTTPS.js
@@ -12,8 +12,10 @@ class ForceHTTPS {
     /**
      * A list of regular expressions to match routes that should be ignored.
      * @type {Array}
+     * @access protected
+     * @ignore
      */
-    this.ignoredRoutes = ignoredRoutes;
+    this._ignoredRoutes = ignoredRoutes;
   }
   /**
    * Returns the Express middleware that forces the redirection to HTTPS.
@@ -24,7 +26,7 @@ class ForceHTTPS {
       if (
         !req.secure &&
         req.get('X-Forwarded-Proto') !== 'https' &&
-        !this.ignoredRoutes.some((expression) => expression.test(req.originalUrl))
+        !this._ignoredRoutes.some((expression) => expression.test(req.originalUrl))
       ) {
         const host = req.get('Host');
         res.redirect(`https://${host}${req.url}`);
@@ -32,6 +34,13 @@ class ForceHTTPS {
         next();
       }
     };
+  }
+  /**
+   * A list of regular expressions to match routes that should be ignored.
+   * @type {Array}
+   */
+  get ignoredRoutes() {
+    return this._ignoredRoutes.slice();
   }
 }
 /**

--- a/src/middlewares/html/fastHTML.js
+++ b/src/middlewares/html/fastHTML.js
@@ -37,34 +37,36 @@ class FastHTML {
     /**
      * A local reference for the `sendFile` service.
      * @type {SendFile}
+     * @access protected
+     * @ignore
      */
-    this.sendFile = sendFile;
+    this._sendFile = sendFile;
     /**
      * The name of the file to serve.
      * @type {string}
      */
-    this.file = file;
+    this._file = file;
     /**
      * A list of regular expressions to match requests paths that should be ignored.
      * @type {Array}
      */
-    this.ignoredRoutes = ignoredRoutes;
+    this._ignoredRoutes = ignoredRoutes;
     /**
      * If specified, a reference for a service that generates HTML files.
      * @type {HTMLGenerator}
      */
-    this.htmlGenerator = htmlGenerator;
+    this._htmlGenerator = htmlGenerator;
     /**
      * Whether or not the file is ready to be served.
      * @type {Boolean}
-     * @ignore
      * @access protected
+     * @ignore
      */
     this._ready = true;
     // If an `HTMLGenerator` service was specified...
-    if (this.htmlGenerator) {
+    if (this._htmlGenerator) {
       // ...get the name of the file from that service.
-      this.file = this.htmlGenerator.getFile();
+      this._file = this._htmlGenerator.getFile();
       /**
        * Mark the `_ready` flag as `false` as this service needs to wait for the generator to
        * create the file.
@@ -79,7 +81,7 @@ class FastHTML {
   middleware() {
     return (req, res, next) => {
       // Validate if the route should be ignored.
-      const shouldIgnore = this.ignoredRoutes
+      const shouldIgnore = this._ignoredRoutes
       .some((expression) => expression.test(req.originalUrl));
       // If the route should be ignored...
       if (shouldIgnore) {
@@ -91,7 +93,7 @@ class FastHTML {
          * calls the method that will notify this service when the file has been created and is
          * ready to be loaded.
          */
-        this.htmlGenerator.whenReady()
+        this._htmlGenerator.whenReady()
         .then(() => {
           // The file is ready to use, so mark the `_ready` flag as `true`.
           this._ready = true;
@@ -112,6 +114,20 @@ class FastHTML {
     };
   }
   /**
+   * The name of the file to serve.
+   * @type {string}
+   */
+  get file() {
+    return this._file;
+  }
+  /**
+   * A list of regular expressions to match requests paths that should be ignored.
+   * @type {Array}
+   */
+  get ignoredRoutes() {
+    return this._ignoredRoutes.slice();
+  }
+  /**
    * Serves the file on the response.
    * @param {ExpressResponse} res  The server response.
    * @param {ExpressNext}     next The functino to call the next middleware.
@@ -120,7 +136,7 @@ class FastHTML {
    */
   _sendHTML(res, next) {
     res.setHeader('Content-Type', mime.getType('html'));
-    this.sendFile(res, this.file, next);
+    this._sendFile(res, this._file, next);
   }
 }
 /**

--- a/src/middlewares/html/showHTML.js
+++ b/src/middlewares/html/showHTML.js
@@ -20,29 +20,35 @@ class ShowHTML {
     /**
      * A local reference for the `sendFile` service.
      * @type {SendFile}
+     * @access protected
+     * @ignore
      */
-    this.sendFile = sendFile;
+    this._sendFile = sendFile;
     /**
      * The name of the file to serve.
      * @type {string}
+     * @access protected
+     * @ignore
      */
-    this.file = file;
+    this._file = file;
     /**
      * If specified, a reference for a service that generates HTML files.
      * @type {HTMLGenerator}
+     * @access protected
+     * @ignore
      */
-    this.htmlGenerator = htmlGenerator;
+    this._htmlGenerator = htmlGenerator;
     /**
      * Whether or not the file is ready to be served.
      * @type {Boolean}
-     * @ignore
      * @access protected
+     * @ignore
      */
     this._ready = true;
     // If an `HTMLGenerator` service was specified...
-    if (this.htmlGenerator) {
+    if (this._htmlGenerator) {
       // ...get the name of the file from that service.
-      this.file = this.htmlGenerator.getFile();
+      this._file = this._htmlGenerator.getFile();
       /**
        * Mark the `_ready` flag as `false` as this service needs to wait for the generator to
        * create the file.
@@ -63,7 +69,7 @@ class ShowHTML {
          * calls the method that will notify this service when the file has been created and is
          * ready to be loaded.
          */
-        this.htmlGenerator.whenReady()
+        this._htmlGenerator.whenReady()
         .then(() => {
           // The file is ready to use, so mark the `_ready` flag as `true`.
           this._ready = true;
@@ -84,6 +90,13 @@ class ShowHTML {
     };
   }
   /**
+   * The name of the file to serve.
+   * @type {string}
+   */
+  get file() {
+    return this._file;
+  }
+  /**
    * Serves the file on the response.
    * @param {ExpressResponse} res  The server response.
    * @param {ExpressNext}     next The functino to call the next middleware.
@@ -92,7 +105,7 @@ class ShowHTML {
    */
   _sendHTML(res, next) {
     res.setHeader('Content-Type', mime.getType('html'));
-    return this.sendFile(res, this.file, next);
+    return this._sendFile(res, this._file, next);
   }
 }
 /**

--- a/src/services/api/client.js
+++ b/src/services/api/client.js
@@ -26,13 +26,17 @@ class APIClient extends APIClientBase {
      * @property {string} url       The API entry point.
      * @property {Object} endpoints A dictionary of named endpoints relative to the API
      *                              entry point.
+     * @access protected
+     * @ignore
      */
-    this.apiConfig = apiConfig;
+    this._apiConfig = Object.freeze(apiConfig);
     /**
      * A local reference for the class the app uses to generate HTTP errors.
      * @type {Class}
+     * @access protected
+     * @ignore
      */
-    this.HTTPError = HTTPError;
+    this._HTTPError = HTTPError;
   }
   /**
    * Formats a response error with the App error class.
@@ -41,7 +45,17 @@ class APIClient extends APIClientBase {
    * @return {HTTPError}
    */
   error(response, status) {
-    return new this.HTTPError(response.data.message, status);
+    return new this._HTTPError(response.data.message, status);
+  }
+  /**
+   * The configuration for the API the client will make requests to.
+   * @type {Object}
+   * @property {string} url       The API entry point.
+   * @property {Object} endpoints A dictionary of named endpoints relative to the API
+   *                              entry point.
+   */
+  get apiConfig() {
+    return this._apiConfig;
   }
 }
 /**

--- a/src/services/api/ensureBearerAuthentication.js
+++ b/src/services/api/ensureBearerAuthentication.js
@@ -16,13 +16,17 @@ class EnsureBearerAuthentication {
     /**
      * A local reference for the class the app uses to generate errors.
      * @type {Class}
+     * @access protected
+     * @ignore
      */
-    this.AppError = AppError;
+    this._AppError = AppError;
     /**
      * The regular expression used to validate the token.
      * @type {RegExp}
+     * @access protected
+     * @ignore
      */
-    this.bearerRegex = /bearer .+$/i;
+    this._bearerRegex = /bearer .+$/i;
   }
   /**
    * Returns the Express middleware that validates the `Authorization` header.
@@ -34,14 +38,14 @@ class EnsureBearerAuthentication {
       // Get the `Authorization` header.
       const { headers: { authorization } } = req;
       // If the header has content the RegExp says it's valid...
-      if (authorization && this.bearerRegex.test(authorization)) {
+      if (authorization && this._bearerRegex.test(authorization)) {
         // ...Set the token as the `bearerToken` property of the current request.
         req.bearerToken = authorization.trim().split(' ').pop();
         // Move to the next middleware.
         next();
       } else {
         // ...otherwise, send an unauthorized error to the next middleware.
-        next(new this.AppError('Unauthorized', {
+        next(new this._AppError('Unauthorized', {
           status: statuses.Unauthorized,
         }));
       }

--- a/src/services/common/appError.js
+++ b/src/services/common/appError.js
@@ -20,7 +20,7 @@ class AppError extends Error {
      * @type {Object}
      * @access protected
      */
-    this._context = context;
+    this._context = Object.freeze(context);
     /**
      * The date of when the error was generated.
      * @type {Date}

--- a/src/services/frontend/frontendFs.js
+++ b/src/services/frontend/frontendFs.js
@@ -19,8 +19,10 @@ class FrontendFs {
     /**
      * A local reference for the `pathUtils` service.
      * @type {PathUtils}
+     * @access protected
+     * @ignore
      */
-    this.pathUtils = pathUtils;
+    this._pathUtils = pathUtils;
   }
   /**
    * Read a file from the file system.
@@ -29,7 +31,7 @@ class FrontendFs {
    * @return {Promise<string,Error>}
    */
   read(filepath, encoding = 'utf-8') {
-    return fs.readFile(this.pathUtils.joinFrom('app', filepath), encoding);
+    return fs.readFile(this._pathUtils.joinFrom('app', filepath), encoding);
   }
   /**
    * Write a file on the file system.
@@ -38,7 +40,7 @@ class FrontendFs {
    * @return {Promise<undefined,Error>}
    */
   write(filepath, data) {
-    return fs.writeFile(this.pathUtils.joinFrom('app', filepath), data);
+    return fs.writeFile(this._pathUtils.joinFrom('app', filepath), data);
   }
   /**
    * Delete a file from the file system.
@@ -46,7 +48,7 @@ class FrontendFs {
    * @return {Promise<undefined,Error>}
    */
   delete(filepath) {
-    return fs.unlink(this.pathUtils.joinFrom('app', filepath));
+    return fs.unlink(this._pathUtils.joinFrom('app', filepath));
   }
 }
 /**

--- a/src/services/html/htmlGenerator.js
+++ b/src/services/html/htmlGenerator.js
@@ -66,7 +66,7 @@ class HTMLGenerator {
      * The service options.
      * @type {HTMLGeneratorOptions}
      */
-    this.options = ObjectUtils.merge({
+    this._options = ObjectUtils.merge({
       template: 'index.tpl.html',
       file: 'index.html',
       deleteTemplateAfter: true,
@@ -82,7 +82,7 @@ class HTMLGenerator {
      * you end up with `['d', 'e', 'c']`, and in this case, that's not very useful.
      */
     if (options.configurationKeys) {
-      this.options.configurationKeys = options.configurationKeys.slice();
+      this._options.configurationKeys = options.configurationKeys.slice();
     }
     // If `valuesService` was specified, check if it has a `getValues` method.
     if (valuesService && typeof valuesService.getValues !== 'function') {
@@ -91,36 +91,44 @@ class HTMLGenerator {
     /**
      * A local reference for the `appConfiguration` service.
      * @type {AppConfiguration}
+     * @access protected
+     * @ignore
      */
-    this.appConfiguration = appConfiguration;
+    this._appConfiguration = appConfiguration;
     /**
      * A local reference for the `appLogger` service.
      * @type {Logger}
+     * @access protected
+     * @ignore
      */
-    this.appLogger = appLogger;
+    this._appLogger = appLogger;
     /**
      * A local reference for the `frontendFs` service.
      * @type {FrontendFs}
+     * @access protected
+     * @ignore
      */
-    this.frontendFs = frontendFs;
+    this._frontendFs = frontendFs;
     /**
      * A local reference for the recieved `valuesService` service.
      * @type {?HTMLGeneratorValuesService}
+     * @access protected
+     * @ignore
      */
-    this.valuesService = valuesService;
+    this._valuesService = valuesService;
     /**
      * Whether or not the file has been generated.
      * @type {Boolean}
-     * @ignore
      * @access protected
+     * @ignore
      */
     this._fileReady = false;
     /**
      * A deferred promise to return when another service asks if the file has been generated. Once
      * this sevice finishes generating the file, the promise will be resolved.
      * @type {Object}
-     * @ignore
      * @access protected
+     * @ignore
      */
     this._fileDeferred = deferred();
   }
@@ -138,7 +146,7 @@ class HTMLGenerator {
    * @return {string}
    */
   getFile() {
-    return this.options.file;
+    return this._options.file;
   }
   /**
    * Get the values that are going to be injected on the file.
@@ -147,16 +155,16 @@ class HTMLGenerator {
   getValues() {
     let valuesPromise;
     // If an `HTMLGeneratorValuesService` was specified...
-    if (this.valuesService) {
+    if (this._valuesService) {
       // ...get the values from there.
-      valuesPromise = this.valuesService.getValues();
-    } else if (this.options.configurationKeys.length) {
+      valuesPromise = this._valuesService.getValues();
+    } else if (this._options.configurationKeys.length) {
       /**
        * ...if there are configuration keys to be copied, set to return an already resolved
        * promise with the settings from the configuration.
        */
       valuesPromise = Promise.resolve(
-        this.appConfiguration.get(this.options.configurationKeys)
+        this._appConfiguration.get(this._options.configurationKeys)
       );
     } else {
       // ...otherwsie, return an already resolved promise with an empty object.
@@ -175,11 +183,11 @@ class HTMLGenerator {
       template,
       deleteTemplateAfter,
       file,
-    } = this.options;
+    } = this._options;
     // Define the variable where the template contents will be saved.
     let templateContents = '';
     // Read the template file.
-    return this.frontendFs.read(`./${template}`)
+    return this._frontendFs.read(`./${template}`)
     .then((contents) => {
       // Save the template contents.
       templateContents = contents;
@@ -190,20 +198,20 @@ class HTMLGenerator {
       // Get the HTML code for the file.
       const html = this._processHTML(templateContents, values);
       // Write the generated file.
-      return this.frontendFs.write(file, html);
+      return this._frontendFs.write(file, html);
     })
     .then(() => {
-      this.appLogger.success(`The HTML was successfully generated (${file})`);
+      this._appLogger.success(`The HTML was successfully generated (${file})`);
       /**
        * If the template needs to be deleted, return the call to the `delete` method, otherwise,
        * just an empty object to continue the promise chain.
        */
-      return deleteTemplateAfter && this.frontendFs.delete(`./${template}`);
+      return deleteTemplateAfter && this._frontendFs.delete(`./${template}`);
     })
     .then(() => {
       // If the template was deleted, log a message informing it.
       if (deleteTemplateAfter) {
-        this.appLogger.info(`The HTML template was successfully removed (${template})`);
+        this._appLogger.info(`The HTML template was successfully removed (${template})`);
       }
       /**
        * Mark the `_fileReady` flag as `true` so the next calls to `whenReady` won't get the
@@ -214,9 +222,16 @@ class HTMLGenerator {
       this._fileDeferred.resolve();
     })
     .catch((error) => {
-      this.appLogger.error('There was an error while generating the HTML');
+      this._appLogger.error('There was an error while generating the HTML');
       return Promise.reject(error);
     });
+  }
+  /**
+   * The service options.
+   * @type {HTMLGeneratorOptions}
+   */
+  get options() {
+    return Object.freeze(this._options);
   }
   /**
    * Creates the code for the HTML file.
@@ -231,7 +246,7 @@ class HTMLGenerator {
       replacePlaceholder,
       valuesExpression,
       variable,
-    } = this.options;
+    } = this._options;
     const htmlObject = JSON.stringify(values);
     let code = template
     .replace(

--- a/src/services/http/http.js
+++ b/src/services/http/http.js
@@ -27,13 +27,17 @@ class HTTP {
     /**
      * Whether or not to log the requests and their responses.
      * @type {Boolean}
+     * @access protected
+     * @ignore
      */
-    this.logRequests = logRequests;
+    this._logRequests = logRequests;
     /**
      * A local reference for the `appLogger` service.
      * @type {AppLogger}
+     * @access protected
+     * @ignore
      */
-    this.appLogger = appLogger;
+    this._appLogger = appLogger;
     /**
      * So it can be sent to other services as a reference.
      * @ignore
@@ -121,13 +125,13 @@ class HTTP {
       fetchOptions.headers = headers;
     }
     // If the `logRequests` flag is `true`, call the method to log the request.
-    if (this.logRequests) {
+    if (this._logRequests) {
       this._logRequest(fetchURL, fetchOptions);
     }
     // Make the request.
     let result = fetch(fetchURL, fetchOptions);
     // If the `logRequests` flag is `true`...
-    if (this.logRequests) {
+    if (this._logRequests) {
       // Add an extra step on the promise chain to log the response.
       result = result.then((response) => {
         this._logResponse(response);
@@ -136,6 +140,13 @@ class HTTP {
     }
     // Return the request promise.
     return result;
+  }
+  /**
+   * Whether or not to log the requests and their responses.
+   * @type {Boolean}
+   */
+  get logRequests() {
+    return this._logRequests;
   }
   /**
    * Log a a request information using the `appLogger` service.
@@ -161,7 +172,7 @@ class HTTP {
       lines.push(`${prefix}body: "${options.body}"`);
     }
 
-    this.appLogger.info(lines);
+    this._appLogger.info(lines);
   }
   /**
    * Log a a response information using the `appLogger` service.
@@ -182,7 +193,7 @@ class HTTP {
       lines.push(`${prefix}${header}: ${value}`);
     });
 
-    this.appLogger.info(lines);
+    this._appLogger.info(lines);
   }
 }
 /**

--- a/src/services/http/responsesBuilder.js
+++ b/src/services/http/responsesBuilder.js
@@ -23,8 +23,10 @@ class ResponsesBuilder {
     /**
      * A local reference for the `appConfiguration` service.
      * @type {AppConfiguration}
+     * @access protected
+     * @ignore
      */
-    this.appConfiguration = appConfiguration;
+    this._appConfiguration = appConfiguration;
   }
   /**
    * Generates and sends a JSON response.
@@ -52,7 +54,7 @@ class ResponsesBuilder {
     .status(status)
     .json({
       metadata: Object.assign({
-        version: this.appConfiguration.get('version'),
+        version: this._appConfiguration.get('version'),
         status,
       }, metadata),
       data,
@@ -83,7 +85,7 @@ class ResponsesBuilder {
     status = statuses.ok,
     options = {}
   ) {
-    const prefix = this.appConfiguration.get('postMessagesPrefix') || '';
+    const prefix = this._appConfiguration.get('postMessagesPrefix') || '';
     const target = options.target || 'window.opener';
     const close = typeof options.close !== 'undefined' ? options.close : true;
     const defaultCloseDelay = 700;

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -99,6 +99,8 @@ describe('app:Jimpex', () => {
     expectedServices.forEach((service) => {
       expect(sut.register).toHaveBeenCalledWith(service);
     });
+    expect(sut.express).toBe(expressMock.mocks);
+    expect(expressMock).toHaveBeenCalledTimes(1);
     expect(expressMock.mocks.enable).toHaveBeenCalledTimes(1);
     expect(expressMock.mocks.enable).toHaveBeenCalledWith('trust proxy');
     expect(expressMock.mocks.disable).toHaveBeenCalledTimes(1);
@@ -706,6 +708,7 @@ describe('app:Jimpex', () => {
     };
     JimpleMock.service('appLogger', appLogger);
     let sut = null;
+    let runningInstance = null;
     const expectedEvents = [
       'before-start',
       'start',
@@ -717,8 +720,12 @@ describe('app:Jimpex', () => {
     // When
     sut = new Sut();
     sut.start();
+    runningInstance = sut.instance;
     sut.stop();
     // Then
+    expect(runningInstance).toEqual({
+      close: expect.any(Function),
+    });
     expect(events.emit).toHaveBeenCalledTimes(expectedEvents.length);
     expectedEvents.forEach((eventName) => {
       expect(events.emit).toHaveBeenCalledWith(eventName, sut);

--- a/tests/controllers/common/configuration.test.js
+++ b/tests/controllers/common/configuration.test.js
@@ -8,7 +8,7 @@ const {
 } = require('/src/controllers/common/configuration');
 
 describe('controllers/common:configuration', () => {
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated an have public methods', () => {
     // Given
     const appConfiguration = 'appConfiguration';
     const responsesBuilder = 'responsesBuilder';
@@ -17,8 +17,9 @@ describe('controllers/common:configuration', () => {
     sut = new ConfigurationController(appConfiguration, responsesBuilder);
     // Then
     expect(sut).toBeInstanceOf(ConfigurationController);
-    expect(sut.appConfiguration).toBe(appConfiguration);
-    expect(sut.responsesBuilder).toBe(responsesBuilder);
+    expect(sut.getConfigurationResponse).toBeFunction();
+    expect(sut.showConfiguration).toBeFunction();
+    expect(sut.switchConfiguration).toBeFunction();
   });
 
   it('should have a generic method to generate a configuration reponse', () => {

--- a/tests/controllers/common/health.test.js
+++ b/tests/controllers/common/health.test.js
@@ -9,7 +9,7 @@ const {
 } = require('/src/controllers/common/health');
 
 describe('controllers/common:health', () => {
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated and have a public method', () => {
     // Given
     const appConfiguration = 'appConfiguration';
     const responsesBuilder = 'responsesBuilder';
@@ -18,8 +18,7 @@ describe('controllers/common:health', () => {
     sut = new HealthController(appConfiguration, responsesBuilder);
     // Then
     expect(sut).toBeInstanceOf(HealthController);
-    expect(sut.appConfiguration).toBe(appConfiguration);
-    expect(sut.responsesBuilder).toBe(responsesBuilder);
+    expect(sut.health).toBeFunction();
   });
 
   it('should have a middleware to show "health" information', () => {

--- a/tests/controllers/common/rootStatics.test.js
+++ b/tests/controllers/common/rootStatics.test.js
@@ -8,7 +8,7 @@ const {
 } = require('/src/controllers/common/rootStatics');
 
 describe('controllers/common:rootStatics', () => {
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated and have public methods', () => {
     // Given
     const sendFile = 'sendFile';
     let sut = null;
@@ -16,7 +16,8 @@ describe('controllers/common:rootStatics', () => {
     sut = new RootStaticsController(sendFile);
     // Then
     expect(sut).toBeInstanceOf(RootStaticsController);
-    expect(sut.sendFile).toBe(sendFile);
+    expect(sut.getFileEntries).toBeFunction();
+    expect(sut.serveFile).toBeFunction();
   });
 
   it('should have a method to return all the files it will serve', () => {

--- a/tests/middlewares/common/errorHandler.test.js
+++ b/tests/middlewares/common/errorHandler.test.js
@@ -9,7 +9,7 @@ const {
 } = require('/src/middlewares/common/errorHandler');
 
 describe('middlewares/common:errorHandler', () => {
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated with default options and have a middleware method', () => {
     // Given
     const appLogger = 'appLogger';
     const responsesBuilder = 'responsesBuilder';
@@ -20,9 +20,7 @@ describe('middlewares/common:errorHandler', () => {
     sut = new ErrorHandler(appLogger, responsesBuilder, showErrors, AppError);
     // Then
     expect(sut).toBeInstanceOf(ErrorHandler);
-    expect(sut.appLogger).toBe(appLogger);
-    expect(sut.responsesBuilder).toBe(responsesBuilder);
-    expect(sut.showErrors).toBe(showErrors);
+    expect(sut.middleware).toBeFunction();
     expect(sut.options).toEqual(({
       default: {
         message: 'Oops! Something went wrong, please try again',

--- a/tests/middlewares/common/forceHTTPS.test.js
+++ b/tests/middlewares/common/forceHTTPS.test.js
@@ -8,7 +8,7 @@ const {
 } = require('/src/middlewares/common/forceHTTPS');
 
 describe('middlewares/common:forceHTTPS', () => {
-  it('should be instantiated with its default values', () => {
+  it('should be instantiated with its default options', () => {
     // Given
     let sut = null;
     // When
@@ -26,7 +26,7 @@ describe('middlewares/common:forceHTTPS', () => {
     sut = new ForceHTTPS(ignoredFiles);
     // Then
     expect(sut).toBeInstanceOf(ForceHTTPS);
-    expect(sut.ignoredRoutes).toBe(ignoredFiles);
+    expect(sut.ignoredRoutes).toEqual(ignoredFiles);
   });
 
   it('should return a middleware to force the traffic to HTTPS', () => {

--- a/tests/middlewares/html/fastHTML.test.js
+++ b/tests/middlewares/html/fastHTML.test.js
@@ -8,7 +8,7 @@ const {
 } = require('/src/middlewares/html/fastHTML');
 
 describe('middlewares/html:fastHTML', () => {
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated', () => {
     // Given
     const sendFile = 'sendFile';
     let sut = null;
@@ -16,7 +16,6 @@ describe('middlewares/html:fastHTML', () => {
     sut = new FastHTML(sendFile);
     // Then
     expect(sut).toBeInstanceOf(FastHTML);
-    expect(sut.sendFile).toBe(sendFile);
   });
 
   it('should be instantiated with the optional htmlGenerator service', () => {
@@ -31,8 +30,6 @@ describe('middlewares/html:fastHTML', () => {
     sut = new FastHTML(sendFile, 'index.html', [], htmlGenerator);
     // Then
     expect(sut).toBeInstanceOf(FastHTML);
-    expect(sut.sendFile).toBe(sendFile);
-    expect(sut.htmlGenerator).toBe(htmlGenerator);
     expect(sut.file).toBe(file);
     expect(htmlGenerator.getFile).toHaveBeenCalledTimes(1);
   });
@@ -55,6 +52,7 @@ describe('middlewares/html:fastHTML', () => {
     sut = new FastHTML(sendFile, file, ignoredRoutes);
     middleware = sut.middleware();
     middleware(request, response, next);
+    // Then
     expect(response.setHeader).toHaveBeenCalledTimes(1);
     expect(response.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
     expect(sendFile).toHaveBeenCalledTimes(1);
@@ -77,6 +75,8 @@ describe('middlewares/html:fastHTML', () => {
     sut = new FastHTML(sendFile, file, ignoredRoutes);
     middleware = sut.middleware();
     middleware(request, response, next);
+    // Then
+    expect(sut.ignoredRoutes).toEqual(ignoredRoutes);
     expect(next).toHaveBeenCalledTimes(1);
     expect(sendFile).toHaveBeenCalledTimes(0);
   });
@@ -104,6 +104,7 @@ describe('middlewares/html:fastHTML', () => {
       sut = new FastHTML(sendFile, '', ignoredRoutes, htmlGenerator);
       middleware = sut.middleware();
       middleware(request, response, () => {
+        // Then
         expect(htmlGenerator.getFile).toHaveBeenCalledTimes(1);
         expect(htmlGenerator.whenReady).toHaveBeenCalledTimes(1);
         expect(sendFile).toHaveBeenCalledTimes(1);
@@ -140,6 +141,7 @@ describe('middlewares/html:fastHTML', () => {
       sut = new FastHTML(sendFile, '', ignoredRoutes, htmlGenerator);
       middleware = sut.middleware();
       middleware(request, response, (result) => {
+        // Then
         expect(result).toBe(error);
         expect(htmlGenerator.getFile).toHaveBeenCalledTimes(1);
         expect(htmlGenerator.whenReady).toHaveBeenCalledTimes(1);

--- a/tests/middlewares/html/showHTML.test.js
+++ b/tests/middlewares/html/showHTML.test.js
@@ -8,7 +8,7 @@ const {
 } = require('/src/middlewares/html/showHTML');
 
 describe('middlewares/html:showHTML', () => {
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated', () => {
     // Given
     const sendFile = 'sendFile';
     let sut = null;
@@ -16,7 +16,6 @@ describe('middlewares/html:showHTML', () => {
     sut = new ShowHTML(sendFile);
     // Then
     expect(sut).toBeInstanceOf(ShowHTML);
-    expect(sut.sendFile).toBe(sendFile);
   });
 
   it('should be instantiated with the optional htmlGenerator service', () => {
@@ -31,8 +30,6 @@ describe('middlewares/html:showHTML', () => {
     sut = new ShowHTML(sendFile, 'index.html', htmlGenerator);
     // Then
     expect(sut).toBeInstanceOf(ShowHTML);
-    expect(sut.sendFile).toBe(sendFile);
-    expect(sut.htmlGenerator).toBe(htmlGenerator);
     expect(sut.file).toBe(file);
     expect(htmlGenerator.getFile).toHaveBeenCalledTimes(1);
   });

--- a/tests/services/api/client.test.js
+++ b/tests/services/api/client.test.js
@@ -9,7 +9,7 @@ const {
 const APIClientBase = require('wootils/shared/apiClient');
 
 describe('services/api:client', () => {
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated with its configuration', () => {
     // Given
     const apiConfig = {
       url: 'my-api',
@@ -20,17 +20,16 @@ describe('services/api:client', () => {
     const http = {
       fetch: () => {},
     };
-    const HTTPError = Error;
+    const HTTPError = 'HTTPError';
     let sut = null;
     // When
     sut = new APIClient(apiConfig, http, HTTPError);
     // Then
     expect(sut).toBeInstanceOf(APIClientBase);
     expect(sut).toBeInstanceOf(APIClient);
-    expect(sut.apiConfig).toBe(apiConfig);
+    expect(sut.apiConfig).toEqual(apiConfig);
     expect(sut.url).toBe(apiConfig.url);
     expect(sut.endpoints).toEqual(apiConfig.endpoints);
-    expect(sut.HTTPError).toBe(HTTPError);
   });
 
   it('should format error responses using the HTTPError service', () => {
@@ -102,7 +101,6 @@ describe('services/api:client', () => {
     expect(sut.apiConfig).toBe(appConfiguration.api);
     expect(sut.url).toBe(appConfiguration.api.url);
     expect(sut.endpoints).toEqual(appConfiguration.api.endpoints);
-    expect(sut.HTTPError).toBe('HTTPError');
     expect(sut.fetchClient).toBe(http.fetch);
     expect(serviceName).toBe('apiClient');
     expect(appConfiguration.get).toHaveBeenCalledTimes(1);
@@ -147,7 +145,6 @@ describe('services/api:client', () => {
     expect(sut.apiConfig).toBe(appConfiguration.apiConfig);
     expect(sut.url).toBe(appConfiguration.apiConfig.url);
     expect(sut.endpoints).toEqual(appConfiguration.apiConfig.endpoints);
-    expect(sut.HTTPError).toBe('HTTPError');
     expect(sut.fetchClient).toBe(http.fetch);
     expect(serviceName).toBe(name);
     expect(appConfiguration.get).toHaveBeenCalledTimes(1);

--- a/tests/services/api/ensureBearerAuthentication.test.js
+++ b/tests/services/api/ensureBearerAuthentication.test.js
@@ -9,7 +9,7 @@ const {
 } = require('/src/services/api/ensureBearerAuthentication');
 
 describe('services/api:ensureBearerAuthentication', () => {
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated', () => {
     // Given
     const AppError = Error;
     let sut = null;
@@ -17,7 +17,6 @@ describe('services/api:ensureBearerAuthentication', () => {
     sut = new EnsureBearerAuthentication(AppError);
     // Then
     expect(sut).toBeInstanceOf(EnsureBearerAuthentication);
-    expect(sut.AppError).toBe(AppError);
   });
 
   it('should have a middleware to unauthorize requests without tokens', () => {

--- a/tests/services/frontend/frontendFs.test.js
+++ b/tests/services/frontend/frontendFs.test.js
@@ -16,7 +16,7 @@ describe('services/frontend:frontendFs', () => {
     fs.unlink.mockReset();
   });
 
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated', () => {
     // Given
     const pathUtils = 'pathUtils';
     let sut = null;
@@ -24,7 +24,6 @@ describe('services/frontend:frontendFs', () => {
     sut = new FrontendFs(pathUtils);
     // Then
     expect(sut).toBeInstanceOf(FrontendFs);
-    expect(sut.pathUtils).toBe(pathUtils);
   });
 
   it('should read a file', () => {
@@ -129,6 +128,5 @@ describe('services/frontend:frontendFs', () => {
     // Then
     expect(serviceName).toBe('frontendFs');
     expect(sut).toBeInstanceOf(FrontendFs);
-    expect(sut.pathUtils).toBe('pathUtils');
   });
 });

--- a/tests/services/html/htmlGenerator.test.js
+++ b/tests/services/html/htmlGenerator.test.js
@@ -15,7 +15,7 @@ describe('services/html:htmlGenerator', () => {
     wootilsMock.reset();
   });
 
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated', () => {
     // Given
     const options = {};
     const appConfiguration = 'appConfiguration';
@@ -40,10 +40,6 @@ describe('services/html:htmlGenerator', () => {
       variable: expect.any(String),
       configurationKeys: expect.any(Array),
     });
-    expect(sut.appConfiguration).toBe(appConfiguration);
-    expect(sut.appLogger).toBe(appLogger);
-    expect(sut.frontendFs).toBe(frontendFs);
-    expect(sut.valuesService).toBeNull();
   });
 
   it('should be instantiated with a custom service to get the template values', () => {
@@ -66,11 +62,6 @@ describe('services/html:htmlGenerator', () => {
     );
     // Then
     expect(sut).toBeInstanceOf(HTMLGenerator);
-    expect(sut.options).toBeObject();
-    expect(sut.appConfiguration).toBe(appConfiguration);
-    expect(sut.appLogger).toBe(appLogger);
-    expect(sut.frontendFs).toBe(frontendFs);
-    expect(sut.valuesService).toEqual(valuesService);
   });
 
   it('should throw an error if the values service doesnt have a `getValues` method', () => {

--- a/tests/services/http/http.test.js
+++ b/tests/services/http/http.test.js
@@ -14,7 +14,7 @@ describe('services/http:http', () => {
     fetch.mockReset();
   });
 
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated', () => {
     // Given
     const logRequests = 'logRequests';
     const appLogger = 'appLogger';
@@ -23,8 +23,6 @@ describe('services/http:http', () => {
     sut = new HTTP(logRequests, appLogger);
     // Then
     expect(sut).toBeInstanceOf(HTTP);
-    expect(sut.logRequests).toBe(logRequests);
-    expect(sut.appLogger).toBe(appLogger);
   });
 
   it('should include a provider for the DIC', () => {
@@ -50,7 +48,6 @@ describe('services/http:http', () => {
     expect(serviceName).toBe('http');
     expect(sut).toBeInstanceOf(HTTP);
     expect(sut.logRequests).toBeFalse();
-    expect(sut.appLogger).toBe('appLogger');
   });
 
   it('should get a request IP from an Express request object', () => {
@@ -394,6 +391,5 @@ describe('services/http:http', () => {
     expect(serviceName).toBe('http');
     expect(sut).toBeInstanceOf(HTTP);
     expect(sut.logRequests).toBeTrue();
-    expect(sut.appLogger).toBe('appLogger');
   });
 });

--- a/tests/services/http/responsesBuilder.test.js
+++ b/tests/services/http/responsesBuilder.test.js
@@ -9,7 +9,7 @@ const {
 } = require('/src/services/http/responsesBuilder');
 
 describe('services/http:responsesBuilder', () => {
-  it('should be instantiated with all its dependencies', () => {
+  it('should be instantiated', () => {
     // Given
     const appConfiguration = 'appConfiguration';
     let sut = null;
@@ -17,7 +17,6 @@ describe('services/http:responsesBuilder', () => {
     sut = new ResponsesBuilder(appConfiguration);
     // Then
     expect(sut).toBeInstanceOf(ResponsesBuilder);
-    expect(sut.appConfiguration).toBe(appConfiguration);
   });
 
   it('should generate and send a basic JSON response', () => {
@@ -191,6 +190,5 @@ describe('services/http:responsesBuilder', () => {
     // Then
     expect(serviceName).toBe('responsesBuilder');
     expect(sut).toBeInstanceOf(ResponsesBuilder);
-    expect(sut.appConfiguration).toBe('appConfiguration');
   });
 });


### PR DESCRIPTION
### What does this PR do?

As the title says, **every service injection is now protected** (prefixed with `_` and with the `@protected` tag).

The reason for this is that it doesn't make sense to have them as public properties, and having less public "things" to maintain makes it easier to make releases.

And yes, I understand the difference between the `protected` and `private`, I know that if I change something protected it would still be breaking.

I also applied the same logic for some services properties, but I kept public getters, so the values are still available to read, but can't be updated.

#### Breaking changes

- `src/app/index`: `options`, `express`, `instance` and `mountQueue` are now protected.
- `src/controllers/common/configuration`: All dependencies are now protected.
- `src/controllers/common/health`: All dependencies are now protected.
- `src/controllers/common/rootStatics`: All dependencies and `files` are now protected.
- `src/middlewares/common/errorHandler`: All dependencies are now protected.
- `src/middlewares/common/forceHTTPS`: `ignoredRoutes` is now protected.
- `src/middlewares/html/fastHTML`: All dependencies, `file` and `ignoredRoutes` are now protected.
- `src/middlewares/html/fastHTML`: All dependencies and `file` are now protected.
- `src/services/api/client`: All dependencies and `apiConfig` are now protected.
- `src/services/api/ensureBearerAuthentication`: All dependencies and `bearerRegex` are now protected.
- `src/services/frontend/frontendFs`: All dependencies are now protected.
- `src/services/html/htmlGenerator`: All dependencies and `options` are now protected.
- `src/services/http`: All dependencies and `logRequests` are now protected.
- `src/services/http`: All dependencies are now protected.

### How should it be tested manually?

Remove all the customs you were using and replace then with the function call; and of course...

```bash
yarn test
# or
npm test
```