### PR TITLE
feat(app): allow the use of Express middlewares

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -139,7 +139,7 @@ class Jimpex extends Jimple {
     throw new Error('This method must to be overwritten');
   }
   /**
-   * Mount a controller on a route point.
+   * Mounts a controller on a route point.
    * @param {string}                       point      The route for the controller.
    * @param {Controller|ControllerCreator} controller The route controller.
    */
@@ -151,19 +151,23 @@ class Jimpex extends Jimple {
     );
   }
   /**
-   * Add a middleware.
-   * @param {Middleware|MiddlewareCreator} middleware The middleware to use.
+   * Adds a middleware.
+   * @param {Middleware|MiddlewareCreator|ExpressMiddleware} middleware The middleware to use.
    */
   use(middleware) {
     this._mountQueue.push((server) => {
-      const middlewareHandler = middleware.connect(this);
-      if (middlewareHandler) {
-        server.use(middlewareHandler);
+      if (typeof middleware.connect === 'function') {
+        const middlewareHandler = middleware.connect(this);
+        if (middlewareHandler) {
+          server.use(middlewareHandler);
+        }
+      } else {
+        server.use(middleware);
       }
     });
   }
   /**
-   * Start the app server.
+   * Starts the app server.
    * @param {function(config:AppConfiguration)} [fn] A callback function to be called when the
    *                                                 server starts.
    * @return {Object} The server instance
@@ -201,14 +205,14 @@ class Jimpex extends Jimple {
     return this.start(fn, port);
   }
   /**
-   * Emit an app event with a reference to this class instance.
+   * Emits an app event with a reference to this class instance.
    * @param {string} name The name of the event.
    */
   emitEvent(name) {
     this.get('events').emit(name, this);
   }
   /**
-   * Disable the server TLS validation.
+   * Disables the server TLS validation.
    */
   disableTLSValidation() {
     // eslint-disable-next-line no-process-env
@@ -227,7 +231,7 @@ class Jimpex extends Jimple {
     }
   }
   /**
-   * Register the _'core services'_.
+   * Registers the _'core services'_.
    * @ignore
    * @access protected
    */
@@ -244,7 +248,7 @@ class Jimpex extends Jimple {
     this.register(rootRequire);
   }
   /**
-   * Create and configure the Express instance.
+   * Creates and configure the Express instance.
    * @ignore
    * @access protected
    */
@@ -333,7 +337,7 @@ class Jimpex extends Jimple {
     this.set('events', () => new EventsHub());
   }
   /**
-   * Create the configuration service.
+   * Creates the configuration service.
    * @ignore
    * @access protected
    */
@@ -383,7 +387,7 @@ class Jimpex extends Jimple {
     }
   }
   /**
-   * Process and mount all the resources on the `mountQueue`.
+   * Processes and mount all the resources on the `mountQueue`.
    * @ignore
    * @access protected
    */

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -1076,6 +1076,59 @@ describe('app:Jimpex', () => {
     });
   });
 
+  it('should mount an Express middleware', () => {
+    // Given
+    class Sut extends Jimpex {
+      boot() {}
+    }
+    const pathUtils = {
+      joinFrom: jest.fn((from, rest) => path.join(from, rest)),
+    };
+    JimpleMock.service('pathUtils', pathUtils);
+    const defaultConfig = {};
+    const rootRequire = jest.fn(() => defaultConfig);
+    JimpleMock.service('rootRequire', rootRequire);
+    const configuration = {
+      port: 2509,
+    };
+    const appConfiguration = {
+      loadFromEnvironment: jest.fn(),
+      get: jest.fn((prop) => configuration[prop]),
+    };
+    JimpleMock.service('appConfiguration', appConfiguration);
+    const events = {
+      emit: jest.fn(),
+    };
+    JimpleMock.service('events', events);
+    const appLogger = {
+      success: jest.fn(),
+    };
+    JimpleMock.service('appLogger', appLogger);
+    const middleware = 'express-middleware';
+    let sut = null;
+    const expectedStaticsFolder = 'app/statics';
+    const expectedMiddlewares = [
+      ['compression-middleware'],
+      ['/statics', expectedStaticsFolder],
+      ['body-parser-json'],
+      ['body-parser-urlencoded'],
+      ['multer-any'],
+    ];
+    const expectedUseCalls = [
+      ...expectedMiddlewares,
+      [middleware],
+    ];
+    // When
+    sut = new Sut();
+    sut.use(middleware);
+    sut.start();
+    // Then
+    expect(expressMock.mocks.use).toHaveBeenCalledTimes(expectedUseCalls.length);
+    expectedUseCalls.forEach((useCall) => {
+      expect(expressMock.mocks.use).toHaveBeenCalledWith(...useCall);
+    });
+  });
+
   it('shouldn\'t mount a middleware if its `connect` method returned a falsy value', () => {
     // Given
     class Sut extends Jimpex {


### PR DESCRIPTION
### What does this PR do?

Now, `.use` allows you to use a regular Express middleware and not just one wrapper with `middleware(...)`:

```js
app.use((req, res, next) => {
  ...
});
```

The thing is that the wrapper is not as required as it's a way for you to get access to the container the moment the app gets started.

### How should it be tested manually?

Try defining a custom middleware without wrapping it; and of course...

```bash
yarn test
# or
npm test
```