### PR TITLE
feat(app): add a method to request an optional dependency

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -139,6 +139,26 @@ class Jimpex extends Jimple {
     throw new Error('This method must to be overwritten');
   }
   /**
+   * Tries to access a service on the container, but if is not present, it won't throw an error, it
+   * will just return `null`.
+   * @param {string} name The name of the service.
+   * @return {*}
+   */
+  try(name) {
+    let result;
+    try {
+      result = this.get(name);
+    } catch (ignore) {
+      /**
+       * The only reason we are ignoring the error is because is expected to throw an error if
+       * the service is not registered.
+       */
+      result = null;
+    }
+
+    return result;
+  }
+  /**
    * Mounts a controller on a route point.
    * @param {string}                       point      The route for the controller.
    * @param {Controller|ControllerCreator} controller The route controller.

--- a/src/middlewares/html/fastHTML.js
+++ b/src/middlewares/html/fastHTML.js
@@ -161,21 +161,12 @@ const fastHTML = middlewareCreator((
   file,
   ignoredRoutes,
   htmlGeneratorServiceName = 'htmlGenerator'
-) => (app) => {
-  let htmlGenerator;
-  try {
-    htmlGenerator = app.get(htmlGeneratorServiceName);
-  } catch (ignore) {
-    htmlGenerator = null;
-  }
-
-  return new FastHTML(
-    app.get('sendFile'),
-    file,
-    ignoredRoutes,
-    htmlGenerator
-  ).middleware();
-});
+) => (app) => new FastHTML(
+  app.get('sendFile'),
+  file,
+  ignoredRoutes,
+  app.try(htmlGeneratorServiceName)
+).middleware());
 
 module.exports = {
   FastHTML,

--- a/src/middlewares/html/showHTML.js
+++ b/src/middlewares/html/showHTML.js
@@ -125,20 +125,11 @@ class ShowHTML {
 const showHTML = middlewareCreator((
   file,
   htmlGeneratorServiceName = 'htmlGenerator'
-) => (app) => {
-  let htmlGenerator;
-  try {
-    htmlGenerator = app.get(htmlGeneratorServiceName);
-  } catch (ignore) {
-    htmlGenerator = null;
-  }
-
-  return new ShowHTML(
-    app.get('sendFile'),
-    file,
-    htmlGenerator
-  ).middleware();
-});
+) => (app) => new ShowHTML(
+  app.get('sendFile'),
+  file,
+  app.try(htmlGeneratorServiceName)
+).middleware());
 
 module.exports = {
   ShowHTML,

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -991,6 +991,46 @@ describe('app:Jimpex', () => {
       success: jest.fn(),
     };
     JimpleMock.service('appLogger', appLogger);
+    let sut = null;
+    let resultAvailable = null;
+    let resultUnavailable = null;
+    // When
+    sut = new Sut();
+    resultAvailable = sut.try('events');
+    resultUnavailable = sut.try('randomService');
+    // Then
+    expect(resultAvailable).toBe(events);
+    expect(resultUnavailable).toBeNull();
+  });
+
+  it('should mount a controller', () => {
+    // Given
+    class Sut extends Jimpex {
+      boot() {}
+    }
+    const pathUtils = {
+      joinFrom: jest.fn((from, rest) => path.join(from, rest)),
+    };
+    JimpleMock.service('pathUtils', pathUtils);
+    const defaultConfig = {};
+    const rootRequire = jest.fn(() => defaultConfig);
+    JimpleMock.service('rootRequire', rootRequire);
+    const configuration = {
+      port: 2509,
+    };
+    const appConfiguration = {
+      loadFromEnvironment: jest.fn(),
+      get: jest.fn((prop) => configuration[prop]),
+    };
+    JimpleMock.service('appConfiguration', appConfiguration);
+    const events = {
+      emit: jest.fn(),
+    };
+    JimpleMock.service('events', events);
+    const appLogger = {
+      success: jest.fn(),
+    };
+    JimpleMock.service('appLogger', appLogger);
     const routes = ['route-a', 'route-b'];
     const point = '/api';
     const controller = {

--- a/tests/middlewares/html/fastHTML.test.js
+++ b/tests/middlewares/html/fastHTML.test.js
@@ -158,19 +158,16 @@ describe('middlewares/html:fastHTML', () => {
     // Given
     const services = {};
     const app = {
-      get: jest.fn((service) => {
-        if (service === 'htmlGenerator') {
-          throw Error();
-        }
-
-        return services[service] || service;
-      }),
+      get: jest.fn((service) => services[service] || service),
+      try: jest.fn(() => null),
     };
     let middleware = null;
     let toCompare = null;
     const expectedGets = [
-      'htmlGenerator',
       'sendFile',
+    ];
+    const expectedTryAttempts = [
+      'htmlGenerator',
     ];
     // When
     middleware = fastHTML.connect(app);
@@ -181,25 +178,26 @@ describe('middlewares/html:fastHTML', () => {
     expectedGets.forEach((service) => {
       expect(app.get).toHaveBeenCalledWith(service);
     });
+    expect(app.try).toHaveBeenCalledTimes(expectedTryAttempts.length);
+    expectedTryAttempts.forEach((service) => {
+      expect(app.try).toHaveBeenCalledWith(service);
+    });
   });
 
   it('should include a middleware creator shorthand to configure its options', () => {
     // Given
     const services = {};
     const app = {
-      get: jest.fn((service) => {
-        if (service === 'htmlGenerator') {
-          throw Error();
-        }
-
-        return services[service] || service;
-      }),
+      get: jest.fn((service) => services[service] || service),
+      try: jest.fn(() => null),
     };
     let middleware = null;
     let toCompare = null;
     const expectedGets = [
-      'htmlGenerator',
       'sendFile',
+    ];
+    const expectedTryAttempts = [
+      'htmlGenerator',
     ];
     // When
     middleware = fastHTML().connect(app);
@@ -209,6 +207,10 @@ describe('middlewares/html:fastHTML', () => {
     expect(app.get).toHaveBeenCalledTimes(expectedGets.length);
     expectedGets.forEach((service) => {
       expect(app.get).toHaveBeenCalledWith(service);
+    });
+    expect(app.try).toHaveBeenCalledTimes(expectedTryAttempts.length);
+    expectedTryAttempts.forEach((service) => {
+      expect(app.try).toHaveBeenCalledWith(service);
     });
   });
 });

--- a/tests/middlewares/html/showHTML.test.js
+++ b/tests/middlewares/html/showHTML.test.js
@@ -126,19 +126,16 @@ describe('middlewares/html:showHTML', () => {
     // Given
     const services = {};
     const app = {
-      get: jest.fn((service) => {
-        if (service === 'htmlGenerator') {
-          throw Error();
-        }
-
-        return services[service] || service;
-      }),
+      get: jest.fn((service) => services[service] || service),
+      try: jest.fn(() => null),
     };
     let middleware = null;
     let toCompare = null;
     const expectedGets = [
-      'htmlGenerator',
       'sendFile',
+    ];
+    const expectedTryAttempts = [
+      'htmlGenerator',
     ];
     // When
     middleware = showHTML.connect(app);
@@ -149,6 +146,10 @@ describe('middlewares/html:showHTML', () => {
     expectedGets.forEach((service) => {
       expect(app.get).toHaveBeenCalledWith(service);
     });
+    expect(app.try).toHaveBeenCalledTimes(expectedTryAttempts.length);
+    expectedTryAttempts.forEach((service) => {
+      expect(app.try).toHaveBeenCalledWith(service);
+    });
   });
 
   it('should include a middleware creator shorthand to configure its options', () => {
@@ -158,17 +159,16 @@ describe('middlewares/html:showHTML', () => {
       getFile: jest.fn(() => ''),
     };
     const app = {
-      get: jest.fn((service) => (
-        service === htmlGeneratorServiceName ?
-          htmlGeneratorService :
-          service
-      )),
+      get: jest.fn((service) => service),
+      try: jest.fn(() => htmlGeneratorService),
     };
     let middleware = null;
     let toCompare = null;
     const expectedGets = [
-      htmlGeneratorServiceName,
       'sendFile',
+    ];
+    const expectedTryAttempts = [
+      htmlGeneratorServiceName,
     ];
     // When
     middleware = showHTML('some-file', htmlGeneratorServiceName).connect(app);
@@ -178,6 +178,10 @@ describe('middlewares/html:showHTML', () => {
     expect(app.get).toHaveBeenCalledTimes(expectedGets.length);
     expectedGets.forEach((service) => {
       expect(app.get).toHaveBeenCalledWith(service);
+    });
+    expect(app.try).toHaveBeenCalledTimes(expectedTryAttempts.length);
+    expectedTryAttempts.forEach((service) => {
+      expect(app.try).toHaveBeenCalledWith(service);
     });
     expect(htmlGeneratorService.getFile).toHaveBeenCalledTimes(1);
   });

--- a/tests/mocks/jimple.mock.js
+++ b/tests/mocks/jimple.mock.js
@@ -2,7 +2,13 @@ const services = {};
 
 const mocks = {
   set: jest.fn(),
-  get: jest.fn((name) => services[name]),
+  get: jest.fn((name) => {
+    if (!services[name]) {
+      throw new Error();
+    }
+
+    return services[name];
+  }),
   register: jest.fn(),
   factory: jest.fn((fn) => fn()),
 };


### PR DESCRIPTION
### What does this PR do?

If you use `app.get(...)` and the resource is not registered, you get an error, so if you are checking if a service exists, you have to wrap the call with a `try-catch`.

This PRs adds a new method to the container `.try(name)`. It basically does the `get` with the `try-catch` and returns `null` if the resource doesn't exist.

At the same time, I updated `fastHTML` and `showHTML`, as both of them check for `htmlGenerator`. They now use `try`.

### How should it be tested manually?

Try calling `try.get('Batman')`, and if it returns anything but `null`, you have my respect :P.

And of course...

```bash
yarn test
# or
npm test
```