### PR TITLE
chore(project): update wootils to get paths on appConfiguration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "wootils": "^2.3.0",
+      "wootils": "^2.4.0",
       "jimple": "^1.5.0",
       "express": "^4.17.1",
       "body-parser": "^1.19.0",

--- a/src/controllers/common/configuration.js
+++ b/src/controllers/common/configuration.js
@@ -72,8 +72,7 @@ class ConfigurationController {
 const configurationController = controller((app) => {
   const routes = [];
   const appConfiguration = app.get('appConfiguration');
-  const debugging = appConfiguration.get('debug');
-  if (debugging && debugging.configurationController === true) {
+  if (appConfiguration.get('debug.configurationController') === true) {
     const router = app.get('router');
     const ctrl = new ConfigurationController(
       appConfiguration,

--- a/src/middlewares/common/errorHandler.js
+++ b/src/middlewares/common/errorHandler.js
@@ -151,8 +151,7 @@ class ErrorHandler {
  * @param {ErrorHandlerOptions} [options] Custom options to modify the middleware behavior.
  */
 const errorHandler = middlewareCreator((options) => (app) => {
-  const debugging = app.get('appConfiguration').get('debug');
-  const showErrors = debugging && debugging.showErrors;
+  const showErrors = app.get('appConfiguration').get('debug.showErrors') === true;
   return new ErrorHandler(
     app.get('appLogger'),
     app.get('responsesBuilder'),

--- a/src/services/http/http.js
+++ b/src/services/http/http.js
@@ -209,8 +209,7 @@ class HTTP {
  */
 const http = provider((app) => {
   app.set('http', () => {
-    const debugging = app.get('appConfiguration').get('debug');
-    const logRequests = !!(debugging && debugging.logRequests === true);
+    const logRequests = app.get('appConfiguration').get('debug.logRequests') === true;
     return new HTTP(logRequests, app.get('appLogger'));
   });
 });

--- a/tests/controllers/common/configuration.test.js
+++ b/tests/controllers/common/configuration.test.js
@@ -209,9 +209,7 @@ describe('controllers/common:configuration', () => {
   it('should return its routes when the debug `configurationController` flag is `true`', () => {
     // Given
     const appConfiguration = {
-      debug: {
-        configurationController: true,
-      },
+      'debug.configurationController': true,
       get: jest.fn((prop) => appConfiguration[prop]),
     };
     const services = {
@@ -243,9 +241,7 @@ describe('controllers/common:configuration', () => {
   it('shouldn\'t return its routes when the debug `configurationController` flag is `false`', () => {
     // Given
     const appConfiguration = {
-      debug: {
-        configurationController: false,
-      },
+      'debug.configurationController': false,
       get: jest.fn((prop) => appConfiguration[prop]),
     };
     const services = {

--- a/tests/middlewares/common/errorHandler.test.js
+++ b/tests/middlewares/common/errorHandler.test.js
@@ -251,10 +251,8 @@ describe('middlewares/common:errorHandler', () => {
   it('should include a middleware shorthand to return its function', () => {
     // Given
     const appConfiguration = {
-      debug: {
-        showErrors: true,
-      },
-      get: jest.fn(() => appConfiguration.debug),
+      'debug.showErrors': true,
+      get: jest.fn((prop) => appConfiguration[prop]),
     };
     const services = {
       appConfiguration,
@@ -285,16 +283,14 @@ describe('middlewares/common:errorHandler', () => {
       expect(app.get).toHaveBeenCalledWith(service);
     });
     expect(appConfiguration.get).toHaveBeenCalledTimes(1);
-    expect(appConfiguration.get).toHaveBeenCalledWith('debug');
+    expect(appConfiguration.get).toHaveBeenCalledWith('debug.showErrors');
   });
 
   it('should include a middleware creator shorthand to modify its options', () => {
     // Given
     const appConfiguration = {
-      debug: {
-        showErrors: true,
-      },
-      get: jest.fn(() => appConfiguration.debug),
+      'debug.showErrors': true,
+      get: jest.fn((prop) => appConfiguration[prop]),
     };
     const services = {
       appConfiguration,
@@ -325,6 +321,6 @@ describe('middlewares/common:errorHandler', () => {
       expect(app.get).toHaveBeenCalledWith(service);
     });
     expect(appConfiguration.get).toHaveBeenCalledTimes(1);
-    expect(appConfiguration.get).toHaveBeenCalledWith('debug');
+    expect(appConfiguration.get).toHaveBeenCalledWith('debug.showErrors');
   });
 });

--- a/tests/services/http/http.test.js
+++ b/tests/services/http/http.test.js
@@ -368,10 +368,8 @@ describe('services/http:http', () => {
   it('should turn on the requests log when registered if the configuration flag is `true`', () => {
     // Given
     const appConfiguration = {
-      debug: {
-        logRequests: true,
-      },
-      get: jest.fn(() => appConfiguration.debug),
+      'debug.logRequests': true,
+      get: jest.fn((prop) => appConfiguration[prop]),
     };
     const services = {
       appConfiguration,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,7 +2512,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -6161,12 +6161,13 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
-wootils@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/wootils/-/wootils-2.3.0.tgz#b628fd4b0b7644ce116456d2f3c223cfddc5e7c5"
-  integrity sha512-VtUPHMR+0NM/+rEtGVZjCbY5ajfI0BpBqpCkepFCqcxvMq9YB/coZX5VAdR/aJHup7HvfROLoABtDYRAe2F1jw==
+wootils@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/wootils/-/wootils-2.4.0.tgz#03235f121cd2b2d1af235c4495f87f2bc20d6b86"
+  integrity sha512-QNpDy2QnQyloB+n/gPX/1pJpFYeSNvG0mVsMtL4w0L3Im9OQaRb9v2AepAUN7d+9bB33s7i4NYtklZO6QtXeaw==
   dependencies:
     colors "1.3.3"
+    extend "^3.0.2"
     fs-extra "8.0.1"
     jimple "1.5.0"
     statuses "1.5.0"


### PR DESCRIPTION
### What does this PR do?

Thanks to [wootils v2.4.0](https://github.com/homer0/wootils/releases/tag/2.4.0), we can now use paths when querying the `appConfiguration` service :D.

Thanks to that, I refactored a little bit the checks for the debug flags.

### How should it be tested manually?

This doesn't change anything, so just run the tests:

```bash
yarn test
# or
npm test
```
