### PR TITLE
feat(controllers): add a gateway controller

### DIFF
--- a/README-esdoc.md
+++ b/README-esdoc.md
@@ -370,6 +370,7 @@ Jimpex comes with a few services, middlewares and controllers that you can impor
 - **Configuration:** Allows you to see and switch the current configuration. It can be enabled or disabled by using a setting on the configuration.
 - **Health:** Shows the version and name of the configuration, just to check the app is running.
 - **Statics:** It allows your app to server specific files from any directory, without having to use the `static` middleware.
+- **Gateway:** It allows you to automatically generate a set of routes that will make gateway requests to an specific API.
 
 [Read more about the built-in controllers](manual/controllers.html)
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Jimpex comes with a few services, middlewares and controllers that you can impor
 - **Configuration:** Allows you to see and switch the current configuration. It can be enabled or disabled by using a setting on the configuration.
 - **Health:** Shows the version and name of the configuration, just to check the app is running.
 - **Statics:** It allows your app to server specific files from any directory, without having to use the `static` middleware.
+- **Gateway:** It allows you to automatically generate a set of routes that will make gateway requests to an specific API.
 
 [Read more about the built-in controllers](./documents/controllers.md)
 

--- a/src/controllers/common/statics.js
+++ b/src/controllers/common/statics.js
@@ -2,6 +2,7 @@ const path = require('path');
 const ObjectUtils = require('wootils/shared/objectUtils');
 const mime = require('mime');
 const { controllerCreator } = require('../../utils/wrappers');
+const { removeSlashes } = require('../../utils/functions');
 
 /**
  * @typdef {Object} StaticsControllerFile
@@ -175,7 +176,7 @@ class StaticsController {
    */
   _createFiles() {
     const { files, paths } = this._options;
-    const routePath = this._removeTrailingSlash(paths.route);
+    const routePath = removeSlashes(paths.route, false, true);
     return files.reduce(
       (formatted, file) => {
         let source;
@@ -189,7 +190,7 @@ class StaticsController {
         }
 
         source = path.join(paths.source, source);
-        route = this._removeLeadingSlash(route);
+        route = removeSlashes(route, true, false);
         route = `${routePath}/${route}`;
 
         return Object.assign({}, formatted, {
@@ -239,26 +240,6 @@ class StaticsController {
 
       this._sendFile(res, file.source, next);
     };
-  }
-  /**
-   * Helper method to remove the leading slash from a URL.
-   * @param {string} url The URL to format.
-   * @return {string}
-   * @access protected
-   * @ignore
-   */
-  _removeLeadingSlash(url) {
-    return url.replace(/^\/+/, '');
-  }
-  /**
-   * Helper method to remove the trailing slash from a URL.
-   * @param {string} url The URL to format.
-   * @return {string}
-   * @access protected
-   * @ignore
-   */
-  _removeTrailingSlash(url) {
-    return url.replace(/\/+$/, '');
   }
 }
 /**

--- a/src/controllers/common/statics.js
+++ b/src/controllers/common/statics.js
@@ -81,31 +81,31 @@ class StaticsController {
     this._files = this._createFiles();
   }
   /**
-   * Creates all the needed routes to serve the files.
+   * Defines all the needed routes to serve the files.
    * @param {ExpressRouter} router           To generate the routes.
    * @param {Array}         [middlewares=[]] A list of custom middlewares that will be added
    *                                         before the one that serves a file.
-   * @return {Array}
+   * @return {ExpressRouter}
    */
-  getRoutes(router, middlewares = []) {
+  addRoutes(router, middlewares = []) {
     const { methods } = this._options;
     const use = methods.all ?
       ['all'] :
       Object.keys(methods).reduce((acc, name) => (methods[name] ? [...acc, name] : acc), []);
 
-    return Object.keys(this._files)
-    .map((route) => {
+    Object.keys(this._files).forEach((route) => {
       const file = this._files[route];
       const fileMiddleware = this._getMiddleware(file);
-      return use.map((method) => this._getRoute(
+      use.forEach((method) => this._addRoute(
         router,
         method,
         file,
         fileMiddleware,
         middlewares
       ));
-    })
-    .reduce((allRoutes, routes) => [...allRoutes, ...routes], []);
+    });
+
+    return router;
   }
   /**
    * The controller configuration options.
@@ -212,11 +212,11 @@ class StaticsController {
    * @param {ExpressMiddleware}     fileMiddleware The middleware that serves the file.
    * @param {Array}                 middlewares    A list of custom middlewares to add before the
    *                                               one that serves the file.
-   * @return {Object} The Express route
+   * @return {ExpressRouter}
    * @access protected
    * @ignore
    */
-  _getRoute(router, method, file, fileMiddleware, middlewares) {
+  _addRoute(router, method, file, fileMiddleware, middlewares) {
     return router[method](file.route, [...middlewares, fileMiddleware]);
   }
   /**
@@ -264,7 +264,7 @@ const staticsController = controllerCreator((options, middlewares) => (app) => {
     ));
   }
 
-  return ctrl.getRoutes(router, useMiddlewares);
+  return ctrl.addRoutes(router, useMiddlewares);
 });
 
 module.exports = {

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,5 +1,7 @@
 const common = require('./common');
+const utils = require('./utils');
 
 module.exports = {
   common,
+  utils,
 };

--- a/src/controllers/utils/gateway.js
+++ b/src/controllers/utils/gateway.js
@@ -1,0 +1,900 @@
+const ObjectUtils = require('wootils/shared/objectUtils');
+const { removeSlashes, createRouteExpression } = require('../../utils/functions');
+const { controllerCreator } = require('../../utils/wrappers');
+
+/**
+ * @typedef {Object} GatewayControllerRouteMethod
+ * @description This object represets an HTTP method for a route the controller will mount.
+ * @property {string}                               method   The name of the HTTP method.
+ * @property {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+ *                                                           responsible from creating the route.
+ * @ignore
+ */
+
+/**
+ * @typedef {Object} GatewayControllerRoute
+ * @description This object contains the information for an specific route the controller will
+ *              mount.
+ * @property {string}                              path    The path the route will have.
+ * @property {Array<GatewayControllerRouteMethod>} methods A list with all the methods the
+ *                                                         controller will use to mount the route.
+ * @ignore
+ */
+
+/**
+ * @typedef {Object} GatewayConfigurationEndpoint
+ * @description Normally, you would define an endpoint with just a string path, but you can use
+ *              this type of object to add extra settings.
+ * @property {string} path   The path to the endpoint relative to the entry point. It can include
+ *                           placeholders for parameters like `/:parameter/`.
+ * @property {string} method The HTTP method for the endpoint. This will tell the gateway the
+ *                           type of route it should mount. If is not specified, it will use
+ *                           `all`.
+ */
+
+/**
+ * @typedef {Object} GatewayConfigurationEndpoints
+ * @description A dictionary of endpoints or sub endpoints the gateway will use in order to mount
+ *              routes.
+ * @property {string|GatewayConfigurationEndpoints|GatewayConfigurationEndpoint} [endpointName]
+ * It can be the path to an actual endpoint, a dictionary of sub endpoints, or a definition of
+ * an endpoint with settings ({@link GatewayConfigurationEndpoint}).
+ */
+
+/**
+ * @typedef {Object} GatewayConfiguration
+ * @description This is a configuration object very similar to the one {@link APIClient} uses in
+ *              order to configure the endpoints; the controller uses it to create the routes and
+ *              to validate the HTTP methods.
+ * @property {string}                        url     The entry point to the API the controller
+ *                                                   will make the requests to.
+ * @property {GatewayConfigurationEndpoints} gateway A dictionary with the endpoints the gateway
+ *                                                   will make available.
+ */
+
+/**
+ * @typedef {Object} GatewayControllerHeadersOptions
+ * @description The options for how the gateway will handle the headers from the requests and the
+ *              responses.
+ * @property {boolean} [useXForwardedFor=true]
+ * Whether or not to include the header with the request's IP address.
+ * @property {boolean} [copyCustomHeaders=true]
+ * Whether or not to copy all custom headers from the request. By custom header, it means all the
+ * headers which names start with `x-`.
+ * @property {Array} [copy=['authorization','content-type', 'referer', 'user-agent']]
+ * A list of "known" headers the gateway will try to copy from the incoming request.
+ * @property {Array} [remove=['server', 'x-powered-by']]
+ * A list of "known" headers the gateway will try to remove the response.
+ */
+
+/**
+ * @typedef {Object} GatewayControllerOptions
+ * @description The options to configure how the gateway will manage the requests and the
+ *              responses.
+ * @property {string} [root='']
+ * This is really a helper for when the gateway is used with an API client. The idea is that,
+ * by default, the routes are mounted on the controller route, but with this option, you can
+ * specify another sub path. For example: The controller is mounted on `/routes`, if you set
+ * `root` to `gateway`, all the routes will be on `/routes/gateway`.
+ * This become important (and useful) when you get the API client configuration (with
+ * `endpointsForAPIClient`): The `url` will be the controller route, but all the endpoints will
+ * be modified and prefixed with the `root`.
+ * @property {string} [configurationSetting='api']
+ * This is another option for when the gateway is used with an API client. When calling
+ * `endpointsForAPIClient`, all the endpoints will be wrapped inside an object named after this
+ * option. For example: `{ url: '...', endpoints: { api: { ... } } }`
+ * @property {GatewayControllerHeadersOptions} [headers]
+ * The options for how the gateway will handle the headers from the requests and the responses.
+ */
+
+/**
+ * @typedef {Object} GatewayControllerCreatorOptions
+ * @description This are the options sent to the controller creator that instantiates
+ *              {@link GatewayController}. They're basically the same as
+ *              {@link GatewayControllerOptions} but with a couple of extra ones.
+ * @param {string} [serviceName='apiGeteway']             The name of the creator will use to
+ *                                                        register the controller in the container.
+ *                                                        No, this is not a typo. The creator will
+ *                                                        register the controller so other
+ *                                                        services can access the
+ *                                                        `endpointsForAPIClient` getter. The
+ *                                                        service will be available after the app
+ *                                                        routes are mounted.
+ *                                                        If this is overwritten, the creator will
+ *                                                        ensure that the name ends with `Gateway`;
+ *                                                        and if overwritten, but it doesn't
+ *                                                        include `Gateway` at the end, and no
+ *                                                        `configurationSetting` was defined, the
+ *                                                        creator will use the custom name
+ *                                                        (without `Gatway`) for
+ *                                                        `configurationSetting`.
+ * @param {string} [helperServiceName='apiGatewayHelper'] The name of the helper service the
+ *                                                        creator will try to obtain from the
+ *                                                        container. If `serviceName` is
+ *                                                        overwritten, the default for this will
+ *                                                        be `${serviceName}Helper`.
+ * @param {string} [configurationSetting='api']           The name of the configuration setting
+ *                                                        where the gateway configuration is
+ *                                                        stored. If not overwritten, check the
+ *                                                        description of `serviceName` to
+ *                                                        understand which will be its default
+ *                                                        value.
+ * @param {Class}  [gatewayClass=GatewayController]       The class the creator will instantiate.
+ *                                                        Similar to {@link APIClient}, this
+ *                                                        allows for extra customization in cases
+ *                                                        you may need multiple gateways.
+ */
+
+/**
+ * @typedef {Object} GatewayControllerRequest
+ * @description This is the information for a request the controller will make.
+ * @property {string}           url     The URL for the request.
+ * @property {HTTPFetchOptions} options The request options.
+ */
+
+/**
+ * @typedef {Object} GatewayControllerEndpointInformation
+ * @description This is the information for an specific endpoint that the gateway may use to
+ *              send to a helper method in order to give it context.
+ * @property {string}                              name     The name of the endpoint, which is
+ *                                                          actually the path inside the gateway
+ *                                                          configuration's `gateway` property.
+ * @property {string|GatewayConfigurationEndpoint} settings The path for the endpoint, or the
+ *                                                          dictionary of settings.
+ */
+
+/**
+ * @typedef {function} GatewayHelperServiceRequestReducer
+ * @description This is called in order to allow the helper to modify the information of a
+ *              request that is about the fired.
+ * @param {GatewayControllerRequest}             request  The information for a request the
+ *                                                        controller will make.
+ * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+ *                                                        responsible of creating the route.
+ * @param {ExpressRequest}                       req      The server's incoming request
+ *                                                        information.
+ * @param {ExpressResponse}                      res      The server's response information.
+ * @param {ExpressNext}                          next     The function to call the next
+ *                                                        middleware.
+ * @return {GatewayControllerRequest}
+ */
+
+/**
+ * @typedef {function} GatewayHelperServiceResponseReducer
+ * @description This is called in order to allow the helper to modify the information of a
+ *              response the gateway made.
+ * @param {Object}                               response The response generated by the fetch
+ *                                                        request.
+ * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+ *                                                        responsible of creating the route.
+ * @param {ExpressRequest}                       req      The server's incoming request
+ *                                                        information.
+ * @param {ExpressResponse}                      res      The server's response information.
+ * @param {ExpressNext}                          next     The function to call the next
+ *                                                        middleware.
+ * @return {Object}
+ */
+
+/**
+ * @typedef {function} GatewayHelperServiceStreamVerification
+ * @description This is called in order to allow the helper to decide whether a fetch request
+ *              response should be added to the server's response stream. This will only be
+ *              called if the helper also implements `handleEndpointResponse`.
+ * @param {Object}                               response The response generated by the fetch
+ *                                                        request.
+ * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+ *                                                        responsible of creating the route.
+ * @param {ExpressRequest}                       req      The server's incoming request
+ *                                                        information.
+ * @param {ExpressResponse}                      res      The server's response information.
+ * @param {ExpressNext}                          next     The function to call the next
+ *                                                        middleware.
+ * @return {boolean}
+ */
+
+/**
+ * @typedef {function} GatewayHelperServiceResponseHandler
+ * @description This is called in order for the helper to handle a response. This is only
+ *              called if `shouldStreamEndpointResponse` returned `false`.
+ * @param {Object}                               response The response generated by the fetch
+ *                                                        request.
+ * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+ *                                                        responsible of creating the route.
+ * @param {ExpressRequest}                       req      The server's incoming request
+ *                                                        information.
+ * @param {ExpressResponse}                      res      The server's response information.
+ * @param {ExpressNext}                          next     The function to call the next
+ *                                                        middleware.
+ */
+
+/**
+ * @typedef {function} GatewayHelperServiceErrorHandler
+ * @description This is called in order for the helper to handle a fetch request error.
+ * @param {Error}                                response The fetch request error.
+ * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+ *                                                        responsible of creating the route.
+ * @param {ExpressRequest}                       req      The server's incoming request
+ *                                                        information.
+ * @param {ExpressResponse}                      res      The server's response information.
+ * @param {ExpressNext}                          next     The function to call the next
+ *                                                        middleware.
+ */
+
+/**
+ * @typedef {Object} GatewayHelperService
+ * @description A service that can have specific methods the gateway will call in order to
+ *              modify requests, responses, handle errors, etc.
+ * @property {?GatewayHelperServiceRequestReducer} reduceEndpointRequest
+ * This is called in order to allow the helper to modify the information of a request that is
+ * about the fired.
+ * @property {?GatewayHelperServiceResponseReducer} reduceEndpointResponse
+ * This is called in order to allow the helper to modify the information of a response the
+ * gateway made.
+ * @property {?GatewayHelperServiceStreamVerification} shouldStreamEndpointResponse
+ * This is called in order to allow the helper to decide whether a fetch request response should
+ * be added to the server's response stream. This will only be called if the helper also
+ * implements `handleEndpointResponse`.
+ * @property {?GatewayHelperServiceResponseHandler} handleEndpointResponse
+ * This is called in order for the helper to handle a response. This is only called if
+ * `shouldStreamEndpointResponse` returned `false`.
+ * @property {?GatewayHelperServiceErrorHandler} handleEndpointError
+ * This is called in order for the helper to handle a fetch request error.
+ */
+
+/**
+ * Geneters routes that will act as a gateway to an specific set of endpoints.
+ * @param {GatewayConfiguration}     gatewayConfig This is a configuration object very similar to
+ *                                                 the one {@link APIClient} uses in order to
+ *                                                 configure the endpoints; the controller uses it
+ *                                                 to create the routes and to validate the HTTP
+ *                                                 methods.
+ * @param {string}                   route         The route where the controller will be mounted.
+ * @param {HTTP}                     http          To make the fetch requests on the routes.
+ * @param {GatewayControllerOptions} [options={}]  The options to configure how the gateway will
+ *                                                 manage the requests and the responses.
+ * @param {?GatewayHelperService}    [helper=null] A service that can have specific methods the
+ *                                                 gateway will call in order to modify requests,
+ *                                                 responses, handle errors, etc.
+ */
+class GatewayController {
+  constructor(gatewayConfig, route, http, options = {}, helperService = null) {
+    /**
+     * The options to configure how the gateway will manage the requests and the responses.
+     * @type {GatewayControllerOptions}
+     * @access protected
+     * @ignore
+     */
+    this._options = this._normalizeOptions(ObjectUtils.merge(
+      {
+        root: '',
+        configurationSetting: 'api',
+        headers: {
+          useXForwardedFor: true,
+          copyCustomHeaders: true,
+          copy: options.headers && options.headers.copy ? options.headers.copy : [
+            'authorization',
+            'content-type',
+            'referer',
+            'user-agent',
+          ],
+          remove: options.headers && options.headers.remove ? options.headers.remove : [
+            'server',
+            'x-powered-by',
+          ],
+        },
+      },
+      options
+    ));
+    /**
+     * The configuration for the API the controller will make requests to.
+     * @type {GatewayConfiguration}
+     * @access protected
+     * @ignore
+     */
+    this._gatewayConfig = Object.assign({}, gatewayConfig, {
+      url: removeSlashes(gatewayConfig.url, false, true),
+    });
+    /**
+     * A local reference for the `http` service.
+     * @type {HTTP}
+     * @access protected
+     * @ignore
+     */
+    this._http = http;
+    /**
+     * A list of the allowed HTTP methods an endpoint can have.
+     * @type {Array}
+     * @access protected
+     * @ignore
+     */
+    this._allowedHTTPMethods = [
+      'get',
+      'head',
+      'post',
+      'put',
+      'delete',
+      'connect',
+      'options',
+      'trace',
+    ];
+    /**
+     * A flat dictionary of the gateway endpoints. The key is the path on the original
+     * dictionary (`this._gatewayConfig.gateway`) and the value is either the path (`string`)
+     * or the endpoint settings ({@link GatewayConfigurationEndpoint}).
+     * @type {Object}
+     * @access protected
+     * @ignore
+     */
+    this._endpoints = this._getNormalizedEndpoints();
+    /**
+     * The route where the controller is mounted.
+     * @type {string}
+     * @access protected
+     * @ignore
+     */
+    this._route = removeSlashes(route);
+    /**
+     * A regular expression that will be used to remove the controller route from a request
+     * path. This will allow the main middleware to extract the path to where the request should
+     * be made.
+     * @type {RegExp}
+     * @access protected
+     * @ignore
+     */
+    this._routeExpression = this._createRouteExpression();
+    /**
+     * This is the list of routes the controller will define.
+     * @type {Array<GatewayControllerRoute>}
+     * @access protected
+     * @ignore
+     */
+    this._routes = this._createEndpointRoutes();
+    /**
+     * An {@link APIClient} configuration based on the controller routes.
+     * @type {APIClientConfiguration}
+     * @access protected
+     * @Ignore
+     */
+    this._apiClientConfiguration = this._createAPIClientConfiguration();
+    /**
+     * A service that can have specific methods the gateway will call in order to modify
+     * requests, responses, handle errors, etc.
+     * @type {?GatewayHelperService}
+     * @access protected
+     */
+    this._helperService = helperService;
+    /**
+     * A dictionary of boolean flags that specify if a helper service has method. This is to
+     * avoid checking if the helper is defined and if "x method" is a function. If no helper
+     * was specified, the object will have all the flags set to `false`.
+     * @type {Object}
+     * @access protected
+     * @ignore
+     */
+    this._helperServiceInfo = this._createHelperServiceInfo();
+  }
+  /**
+   * Defines all the routes on a given router.
+   * @param {ExpressRouter} router           The router where all the routes will be added.
+   * @param {Array}         [middlewares=[]] A list of custom middlewares that will be added before
+   *                                         the one that makes the request.
+   * @return {ExpressRouter}
+   */
+  addRoutes(router, middlewares = []) {
+    this._routes.forEach((route) => route.methods.forEach((info) => this._addRoute(
+      router,
+      info.method,
+      route.path,
+      this._getMiddleware(info.endpoint),
+      middlewares
+    )));
+
+    return router;
+  }
+  /**
+   * An {@link APIClient} configuration based on the controller routes.
+     * @type {APIClientConfiguration}
+   */
+  get endpointsForAPIClient() {
+    return this._apiClientConfiguration;
+  }
+  /**
+   * The configuration for the API the controller will make requests to.
+   * @type {GatewayConfiguration}
+   */
+  get gatewayConfig() {
+    return this._gatewayConfig;
+  }
+  /**
+   * The options to configure how the gateway will manage the requests and the responses.
+   * @type {GatewayControllerOptions}
+   */
+  get options() {
+    return this._options;
+  }
+  /**
+   * Normalizes the options recevied by the controller:
+   * - Removes any trailing and leading slashes from the `root` path, if defined.
+   * @param {GatewayControllerOptions} options The options to normalize.
+   * @return {GatewayControllerOptions}
+   * @access protected
+   * @ignore
+   */
+  _normalizeOptions(options) {
+    let newOptions;
+    if (options.root) {
+      const root = removeSlashes(options.root).trim();
+      newOptions = Object.assign({}, options, { root });
+    } else {
+      newOptions = options;
+    }
+
+    return newOptions;
+  }
+  /**
+   * Flattens all the endpoints from gateway configuration into a one level dictionary, where the
+   * key are the paths they used to have on the original configuration, and the values are the
+   * endpoints definitions.
+   * @return {Object}
+   * @access protected
+   * @ignore
+   */
+  _getNormalizedEndpoints() {
+    return ObjectUtils.flat(
+      this._gatewayConfig.gateway,
+      '.',
+      '',
+      (ignore, value) => typeof value.path === 'undefined'
+    );
+  }
+  /**
+   * Creates a regular expression the main middleware will later use in order to remove the
+   * controller route from the request url. That's needed in order to build the URL where the
+   * request will be made.
+   * @return {RegExp}
+   * @access protected
+   * @ignore
+   */
+  _createRouteExpression() {
+    return createRouteExpression(
+      this._options.root ? `${this._route}/${this._options.root}` : this._route,
+      true,
+      true
+    );
+  }
+  /**
+   * This is a helper method used in order to validate if an HTTP method can be used in order to
+   * define a route in the router. If the given method is not on the list of allowed methods,
+   * it will be "normalized" to `all`. It also transforms the method into lower case.
+   * @param {string} method The method to validate.
+   * @return {string}
+   * @access protected
+   * @ignore
+   */
+  _normalizeHTTPMethod(method) {
+    const newMethod = method.toLowerCase();
+    return this._allowedHTTPMethods.includes(newMethod) ? newMethod : 'all';
+  }
+  /**
+   * Based on the information from the endpoints, this method will create the routes the
+   * controller will later add on a router.
+   * @return {Array<GatewayControllerRoute>}
+   * @throws {Error} If there's more than one endpoint using the same path with the same HTTP
+   *                 method.
+   * @access protected
+   * @ignore
+   */
+  _createEndpointRoutes() {
+    const routes = {};
+    Object.keys(this._endpoints).forEach((name) => {
+      const endpoint = this._endpoints[name];
+      let endpointPath;
+      let endpointMethod;
+      if (typeof endpoint === 'string') {
+        endpointPath = endpoint;
+        endpointMethod = 'all';
+      } else {
+        endpointPath = endpoint.path;
+        endpointMethod = endpoint.method ?
+          this._normalizeHTTPMethod(endpoint.method) :
+          'all';
+      }
+
+      endpointPath = removeSlashes(endpointPath);
+      if (!routes[endpointPath]) {
+        routes[endpointPath] = {
+          path: endpointPath,
+          methods: {},
+        };
+      }
+
+      if (routes[endpointPath].methods[endpointMethod]) {
+        const repeatedEndpoint = routes[endpointPath].methods[endpointMethod];
+        throw new Error(
+          'You can\'t have two gateway endpoints to the same path and with the same ' +
+          `HTTP method: '${repeatedEndpoint}' and '${name}'`
+        );
+      }
+
+      routes[endpointPath].methods[endpointMethod] = name;
+    });
+
+    return Object.keys(routes)
+    .map((endpointPath) => ({
+      path: routes[endpointPath].path,
+      methods: Object.keys(routes[endpointPath].methods).map((methodName) => ({
+        method: methodName,
+        endpoint: {
+          name: routes[endpointPath].methods[methodName],
+          settings: this._endpoints[routes[endpointPath].methods[methodName]],
+        },
+      })),
+    }));
+  }
+  /**
+   * Based on the controller options and the gateway endpoints, this method will create an API
+   * client configuration that can be used to make requests to this controller.
+   * @return {APIClientConfiguration}
+   * @access protected
+   * @ignore
+   */
+  _createAPIClientConfiguration() {
+    let endpoints;
+    const { root } = this._options;
+    if (root) {
+      endpoints = Object.keys(this._endpoints).reduce(
+        (acc, name) => {
+          const endpoint = this._endpoints[name];
+          let newEndpoint;
+          if (typeof endpoint === 'string') {
+            newEndpoint = removeSlashes(endpoint);
+            newEndpoint = `${root}/${newEndpoint}`;
+          } else {
+            const endpointPath = removeSlashes(endpoint.path);
+            newEndpoint = Object.assign({}, endpoint, {
+              path: `${root}/${endpointPath}`,
+            });
+          }
+
+          return Object.assign({}, acc, {
+            [name]: newEndpoint,
+          });
+        },
+        {}
+      );
+    } else {
+      endpoints = this._endpoints;
+    }
+    return {
+      url: `/${this._route}`,
+      endpoints: {
+        [this._options.configurationSetting]: ObjectUtils.unflat(endpoints),
+      },
+    };
+  }
+  /**
+   * Validates if a server helper exists and creates a dictionary with flags for all the methods
+   * a helper can have; this will allow other methods to check if the "helper method X" is
+   * available without having to check if the helper is defined and if "method X" is a function.
+   * @return {Object}
+   * @access protected
+   * @ignore
+   */
+  _createHelperServiceInfo() {
+    const methods = [
+      'reduceEndpointRequest',
+      'reduceEndpointResponse',
+      'shouldStreamEndpointResponse',
+      'handleEndpointResponse',
+      'handleEndpointError',
+    ];
+    let result;
+    if (this._helperService) {
+      result = methods.reduce(
+        (methodsDict, name) => Object.assign({}, methodsDict, {
+          [name]: typeof this._helperService[name] === 'function',
+        }),
+        {}
+      );
+    } else {
+      result = methods.reduce(
+        (methodsDict, name) => Object.assign({}, methodsDict, { [name]: false }),
+        {}
+      );
+    }
+
+    return result;
+  }
+  /**
+   * Adds a route on a given router.
+   * @param {ExpressRouter}     router              The router where the route will be added.
+   * @param {string}            method              The HTTP method for the route.
+   * @param {string}            route               The path for the route.
+   * @param {ExpressMiddleware} endpointMiddleware  The middleware that makes the request.
+   * @param {Array}             middlewares         Extra middlewares to add before the main one.
+   *
+   * @return {ExpressRouter}
+   * @access protected
+   * @ignore
+   */
+  _addRoute(router, method, route, endpointMiddleware, middlewares) {
+    return router[method](route, [...middlewares, endpointMiddleware]);
+  }
+  /**
+   * Generates a middleware that will make a request and stream back the response.
+   * @param {GatewayControllerEndpointInformation} endpoint The information for the enpdoint for
+   *                                                        which the middleware is being created.
+   * @return {ExpressMiddleware}
+   * @access protected
+   * @ignore
+   */
+  _getMiddleware(endpoint) {
+    return (req, res, next) => {
+      // Remove the controller route from the requested URL.
+      const reqPath = req.originalUrl.replace(this._routeExpression, '');
+      // Define the request options.
+      const options = {
+        method: req.method.toUpperCase(),
+        headers: {},
+      };
+      // Copy the specified headers from the incoming request.
+      this._options.headers.copy.forEach((name) => {
+        if (req.headers[name]) {
+          options.headers[name] = req.headers[name];
+        }
+      });
+      // If enabled, copy the custom headers.
+      if (this._options.headers.copyCustomHeaders) {
+        options.headers = ObjectUtils.merge(
+          options.headers,
+          this._http.getCustomHeadersFromRequest(req)
+        );
+      }
+      // If enabled, add the header with the request's IP.
+      if (this._options.headers.useXForwardedFor) {
+        options.headers['x-forwarded-for'] = this._http.getIPFromRequest(req);
+      }
+      /**
+       * If the request has a body and the method is not `GET`, stringify it and addit to
+       * the options.
+       */
+      if (options.method !== 'GET' && typeof req.body === 'object') {
+        options.body = JSON.stringify(req.body);
+        // If there's no `content-type`, let's assume it's JSON.
+        if (!options.headers['content-type']) {
+          options.headers['content-type'] = 'application/json';
+        }
+      }
+      // Reduce the request information.
+      const request = this._reduceEndpointRequest(
+        {
+          url: `${this._gatewayConfig.url}/${reqPath}`,
+          options,
+        },
+        endpoint,
+        req,
+        res,
+        next
+      );
+      // Make the fetch request.
+      return this._http.fetch(request.url, request.options)
+      .then((response) => {
+        // Reduce the response.
+        const newResponse = this._reduceEndpointResponse(response, endpoint, req, res, next);
+        // If the response should be sent down on the stream...
+        if (this._shouldStreamEndpointResponse(newResponse, endpoint, req, res, next)) {
+          // Update the server's response status.
+          res.status(newResponse.status);
+          // Copy the headers.
+          newResponse.headers.forEach((value, name) => {
+            if (!this._options.headers.remove.includes(name)) {
+              res.setHeader(name, value);
+            }
+          });
+          // Pipe the server's response into the fetch response stream.
+          newResponse.body
+          .pipe(res)
+          .on('error', (error) => {
+            next(error);
+          });
+        } else {
+          // Otherwise, let the helper handle the response.
+          this._handleEndpointResponse(newResponse, endpoint, req, res, next);
+        }
+      })
+      .catch((error) => this._handleEndpointError(error, endpoint, req, res, next));
+    };
+  }
+  /**
+   * This method is called in order to reduce a fetch request information. It will check if a
+   * helper is defined and allow it to do it, or fallback and return the given information.
+   * @param {GatewayControllerRequest}             request  The information for a request the
+   *                                                        controller will make.
+   * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+   *                                                        responsible of creating the route.
+   * @param {ExpressRequest}                       req      The server's incoming request
+   *                                                        information.
+   * @param {ExpressResponse}                      res      The server's response information.
+   * @param {ExpressNext}                          next     The function to call the next
+   *                                                        middleware.
+   * @return {GatewayControllerRequest}
+   * @access protected
+   * @ignore
+   */
+  _reduceEndpointRequest(request, endpoint, req, res, next) {
+    return this._helperServiceInfo.reduceEndpointRequest ?
+      this._helperService.reduceEndpointRequest(request, endpoint, req, res, next) :
+      request;
+  }
+  /**
+   * This method is called in order to reduce a fetch response information. It will check if a
+   * helper is defined and allow it to do it, or fallback and return the given information.
+   * @param {Object}                               response The response generated by the fetch
+   *                                                        request.
+   * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+   *                                                        responsible of creating the route.
+   * @param {ExpressRequest}                       req      The server's incoming request
+   *                                                        information.
+   * @param {ExpressResponse}                      res      The server's response information.
+   * @param {ExpressNext}                          next     The function to call the next
+   *                                                        middleware.
+   * @return {Object}
+   * @access protected
+   * @ignore
+   */
+
+  _reduceEndpointResponse(response, endpoint, req, res, next) {
+    return this._helperServiceInfo.reduceEndpointResponse ?
+      this._helperService.reduceEndpointResponse(response, endpoint, req, res, next) :
+      response;
+  }
+  /**
+   * This method is called in order to validate if the main middleware should pipe the fetch
+   * response stream into the server's response or if the helper will handle the response.
+   * This method will only call the helper if it implements both `shouldStreamEndpointResponse`
+   * and `handleEndpointResponse`
+   * @param {Object}                               response The response generated by the fetch
+   *                                                        request.
+   * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+   *                                                        responsible of creating the route.
+   * @param {ExpressRequest}                       req      The server's incoming request
+   *                                                        information.
+   * @param {ExpressResponse}                      res      The server's response information.
+   * @param {ExpressNext}                          next     The function to call the next
+   *                                                        middleware.
+   * @return {boolean}
+   * @access protected
+   * @ignore
+   */
+  _shouldStreamEndpointResponse(response, endpoint, req, res, next) {
+    return (
+      this._helperServiceInfo.shouldStreamEndpointResponse &&
+      this._helperServiceInfo.handleEndpointResponse
+    ) ?
+      this._helperService.shouldStreamEndpointResponse(response, endpoint, req, res, next) :
+      true;
+  }
+  /**
+   * This is called when the helper say that a fetch response shouldn't be sent, so the controller
+   * will allow it to handle the response by itself.
+   * @param {Object}                               response The response generated by the fetch
+   *                                                        request.
+   * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+   *                                                        responsible of creating the route.
+   * @param {ExpressRequest}                       req      The server's incoming request
+   *                                                        information.
+   * @param {ExpressResponse}                      res      The server's response information.
+   * @param {ExpressNext}                          next     The function to call the next
+   *                                                        middleware.
+   * @return {*}
+   * @access protected
+   * @ignore
+   */
+  _handleEndpointResponse(response, endpoint, req, res, next) {
+    return this._helperService.handleEndpointResponse(response, endpoint, req, res, next);
+  }
+  /**
+   * This method is called in order to handle a fetch request error. It will check if a
+   * helper is defined and allow it to do it, or fallback and call the next middleware.
+   * @param {Error}                                response The fetch request error.
+   * @param {GatewayControllerEndpointInformation} endpoint The information for the endpoint
+   *                                                        responsible of creating the route.
+   * @param {ExpressRequest}                       req      The server's incoming request
+   *                                                        information.
+   * @param {ExpressResponse}                      res      The server's response information.
+   * @param {ExpressNext}                          next     The function to call the next
+   *                                                        middleware.
+   * @return {*}
+   * @access protected
+   * @ignore
+   */
+  _handleEndpointError(error, endpoint, req, res, next) {
+    return this._helperServiceInfo.handleEndpointError ?
+      this._helperService.handleEndpointError(error, endpoint, req, res, next) :
+      next(error);
+  }
+}
+/**
+ * This controller allows you to have gateway routes that actually make requests and respond with
+ * the contents from an specified API.
+ * @type {ControllerCreator}
+ * @param {GatewayControllerCreatorOptions} [options]     The options to customize the controller.
+ * @param {Function():Array}                [middlewares] This function can be used to add custom
+ *                                                        middlewares on the gateway routes. If
+ *                                                        implemented, it must return a list of
+ *                                                        middlewares when executed.
+ */
+const gatewayController = controllerCreator((
+  options = {},
+  middlewares = null
+) => (app, route) => {
+  /**
+   * Formats the name in order to keep consistency with the helper service and the configuration
+   * setting: If the `serviceName` is different from the default, make sure it ends with
+   * `Gateway`, set the default helper service name to `${serviceName}Helper` and the default
+   * configuration setting to the same as the service name (without the `Gateway`).
+   * This way, if you just use `myApi`, the service name will be `myApiGateway`, the helper name
+   * will be `myApiGatewayHelper` and the configuration setting `myApi`.
+   */
+  const defaultServiceName = 'apiGateway';
+  let defaultHelperServiceName = 'apiGatewayHelper';
+  let defaultConfigurationSetting = 'api';
+  let { serviceName = defaultServiceName } = options;
+  if (serviceName !== defaultServiceName) {
+    defaultConfigurationSetting = serviceName;
+    if (!serviceName.match(/gateway$/i)) {
+      serviceName = `${serviceName}Gateway`;
+    }
+    defaultHelperServiceName = `${serviceName}Helper`;
+  }
+  /**
+   * Get the settings the controller needs in order to use with the container before creating
+   * the instance.
+   */
+  const {
+    helperServiceName = defaultHelperServiceName,
+    configurationSetting = defaultConfigurationSetting,
+    GatewayClass = GatewayController,
+  } = options;
+  /**
+   * Update the options with the resolved configuration setting name, because the class will
+   * needed when generating API Client endpoints.
+   */
+  const newOptions = Object.assign({}, options, {
+    configurationSetting,
+  });
+  // Get the gateway configuration.
+  const gatewayConfig = app.get('appConfiguration').get(configurationSetting);
+  // Generate the controller
+  const ctrl = new GatewayClass(
+    gatewayConfig,
+    app.get('http'),
+    route,
+    newOptions,
+    helperServiceName ? app.try(helperServiceName) : null
+  );
+  /**
+   * Register a service for the controller so other services can ask for the endpoints formatted
+   * for an API Client.
+   */
+  app.set(serviceName, () => ctrl);
+  /**
+   * Check if there are actual middlewares to be included, and in case there are Jimpex
+   * middlewares, connect them
+   */
+  let useMiddlewares;
+  if (middlewares) {
+    useMiddlewares = middlewares(app).map((middleware) => (
+      middleware.connect ?
+        middleware.connect(app) :
+        middleware
+    ));
+  }
+  // Add the routes to the router and return it.
+  return ctrl.addRoutes(app.get('router'), useMiddlewares);
+});
+
+module.exports = {
+  GatewayController,
+  gatewayController,
+};

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -1,0 +1,5 @@
+const { gatewayController } = require('./gateway');
+
+module.exports = {
+  gatewayController,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const {
   middleware,
   middlewareCreator,
 } = require('./utils/wrappers');
+const utils = require('./utils/functions');
 
 module.exports = {
   controller,
@@ -25,5 +26,6 @@ module.exports = {
   providers,
   services,
   eventNames,
+  utils,
   Jimpex,
 };

--- a/src/services/http/apiClient.js
+++ b/src/services/http/apiClient.js
@@ -13,6 +13,14 @@ const { providerCreator } = require('../../utils/wrappers');
  */
 
 /**
+ * @typedef {Object} APIClientConfiguration
+ * @description The configuration for the API the client will make requests to.
+ * @property {string}             url       The API entry point.
+ * @property {APIClientEndpoints} endpoints A dictionary of named endpoints relative to the API
+ *                                          entry point.
+ */
+
+/**
  * An API client for the app to use. What makes this service special is that its that it formats
  * the received errors using the `AppError` service class and as fetch function it uses the
  * `http` service, allowing the app to to internally handle all the requests and responses.
@@ -20,24 +28,17 @@ const { providerCreator } = require('../../utils/wrappers');
  */
 class APIClient extends APIClientBase {
   /**
-   * Class constructor.
-   * @param {Object}             apiConfig           The configuration for the API the client will
-   *                                                 make requests to.
-   * @param {string}             apiConfig.url       The API entry point.
-   * @param {APIClientEndpoints} apiConfig.endpoints A dictionary of named endpoints relative to
-   *                                                 the API entry point.
-   * @param {HTTP}               http                To get the `fetch` function for this service
-   *                                                 to use on all the requests.
-   * @param {Class}              HTTPError           To format the received errors.
+   * @param {APIClientConfiguration} apiConfig The configuration for the API the client will
+   *                                           make requests to.
+   * @param {HTTP}                   http      To get the `fetch` function for this service
+   *                                           to use on all the requests.
+   * @param {Class}                  HTTPError To format the received errors.
    */
   constructor(apiConfig, http, HTTPError) {
     super(apiConfig.url, apiConfig.endpoints, http.fetch);
     /**
      * The configuration for the API the client will make requests to.
-     * @type {Object}
-     * @property {string} url       The API entry point.
-     * @property {Object} endpoints A dictionary of named endpoints relative to the API
-     *                              entry point.
+     * @type {APIClientConfiguration}
      * @access protected
      * @ignore
      */

--- a/src/services/http/http.js
+++ b/src/services/http/http.js
@@ -56,8 +56,8 @@ class HTTP {
       req.connection.socket.remoteAddress;
   }
   /**
-   * Get a dictionary with all the custom headers a request has. By custom header it means all the
-   * headers which name start with `x-`.
+   * Creates a dictionary with all the custom headers a request has. By custom header it means all
+   * the headers which name start with `x-`.
    * This method doesn't copy `x-forwarded-for` as the `fetch` method generates it by calling
    * `getIPFromRequest`.
    * @param {ExpressRequest} req The request from which it will try to get the headers.
@@ -72,6 +72,28 @@ class HTTP {
     });
 
     return headers;
+  }
+  /**
+   * It takes a dictionary of headers and normalize the names so each word will start with an
+   * upper case character. This is helpful in case you added custom headers and didn't care about
+   * the casing, or when copying headers from a server request, in which case they are all
+   * tranformed to lower case.
+   * @param {Object} headers The dictionary of headers to normalize.
+   * @return {Object}
+   */
+  normalizeHeaders(headers) {
+    return Object.keys(headers).reduce(
+      (newHeaders, name) => {
+        const newName = name
+        .split('-')
+        .map((part) => part.replace(/^(\w)/, (ignore, letter) => letter.toUpperCase()))
+        .join('-');
+        return Object.assign({}, newHeaders, {
+          [newName]: headers[name],
+        });
+      },
+      {}
+    );
   }
   /**
    * Make a request.
@@ -122,7 +144,7 @@ class HTTP {
      * to avoid sending an empty object.
      */
     if (Object.keys(headers).length) {
-      fetchOptions.headers = headers;
+      fetchOptions.headers = this.normalizeHeaders(headers);
     }
     // If the `logRequests` flag is `true`, call the method to log the request.
     if (this._logRequests) {

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,0 +1,64 @@
+/**
+ * Removes any leading slash from a URL.
+ * @param {string} url The URL to format.
+ * @return {string}
+ */
+const removeLeadingSlash = (url) => url.replace(/^\/+/, '');
+/**
+ * Removes any trailing slash from a URL.
+ * @param {string} url The URL to format.
+ * @return {string}
+ */
+const removeTrailingSlash = (url) => url.replace(/\/+$/, '');
+/**
+ * Remove any leading and trailing slash from a URL.
+ * @param {string}  url             The URL to format.
+ * @param {boolean} [leading=true]  Whether or not to remove any leading slash.
+ * @param {boolean} [trailing=true] Whether or not to remove the trailing slash.
+ * @return {string}
+ */
+const removeSlashes = (url, leading = true, trailing = true) => {
+  const newUrl = leading ? removeLeadingSlash(url) : url;
+  return trailing ? removeTrailingSlash(newUrl) : newUrl;
+};
+/**
+ * Escapes a string to be used on `new RegExp(...)`.
+ * @param {string} text The text to escape.
+ * @return {string}
+ */
+const escapeForRegExp = (text) => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+/**
+ * Given a server route definition, this function creates a regular expression to match
+ * it: The expression replaces the routes parameters with placeholders so it can be compared
+ * with real routes.
+ * @param {string}  route                 The route from which the expression will be created.
+ * @param {boolean} [leadingSlash=true]   Whether or not the expression should match a leading
+ *                                        slash.
+ * @param {boolean} [trailingSlash=false] Whether or not the expression should match a trailing
+ *                                        slash. The reason this is `false` by default is because
+ *                                        these expressions are often used to match against
+ *                                        incoming requests, and they don't have a trailing slash.
+ * @return {RegExp}
+ */
+const createRouteExpression = (route, leadingSlash = true, trailingSlash = false) => {
+  let expression = removeSlashes(route)
+  .split('/')
+  .map((part) => (part.startsWith(':') ? '(?:([^\\/]+?))' : escapeForRegExp(part)))
+  .join('\\/');
+  if (leadingSlash) {
+    expression = `\\/${expression}`;
+  }
+  if (trailingSlash) {
+    expression = `${expression}\\/`;
+  }
+
+  return new RegExp(expression);
+};
+
+module.exports = {
+  createRouteExpression,
+  escapeForRegExp,
+  removeLeadingSlash,
+  removeSlashes,
+  removeTrailingSlash,
+};

--- a/tests/controllers/common/statics.test.js
+++ b/tests/controllers/common/statics.test.js
@@ -1,3 +1,4 @@
+jest.unmock('/src/utils/functions');
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/controllers/common/statics');
 

--- a/tests/controllers/common/statics.test.js
+++ b/tests/controllers/common/statics.test.js
@@ -18,7 +18,7 @@ describe('controllers/common:statics', () => {
     sut = new StaticsController(sendFile);
     // Then
     expect(sut).toBeInstanceOf(StaticsController);
-    expect(sut.getRoutes).toBeFunction();
+    expect(sut.addRoutes).toBeFunction();
     expect(sut.options).toEqual({
       files: ['favicon.ico', 'index.html'],
       methods: {
@@ -52,7 +52,7 @@ describe('controllers/common:statics', () => {
     sut = new StaticsController(sendFile, options);
     // Then
     expect(sut).toBeInstanceOf(StaticsController);
-    expect(sut.getRoutes).toBeFunction();
+    expect(sut.addRoutes).toBeFunction();
     expect(sut.options).toEqual(options);
   });
 
@@ -108,23 +108,20 @@ describe('controllers/common:statics', () => {
     .toThrow(/is not a valid HTTP method/i);
   });
 
-  it('should generate `get` routes for all the files', () => {
+  it('should register `get` routes for all the files', () => {
     // Given
     const sendFile = 'sendFile';
     const options = {
       files: ['charito.html'],
     };
-    const route = 'route';
     const router = {
-      get: jest.fn(() => route),
+      get: jest.fn(() => router),
     };
     let sut = null;
-    let result = null;
     // When
     sut = new StaticsController(sendFile, options);
-    result = sut.getRoutes(router);
+    sut.addRoutes(router);
     // Then
-    expect(result).toEqual(options.files.map(() => route));
     expect(router.get).toHaveBeenCalledTimes(options.files.length);
     options.files.forEach((file) => {
       expect(router.get).toHaveBeenCalledWith(`/${file}`, [expect.any(Function)]);
@@ -140,17 +137,14 @@ describe('controllers/common:statics', () => {
         all: true,
       },
     };
-    const route = 'route';
     const router = {
-      all: jest.fn(() => route),
+      all: jest.fn(() => router),
     };
     let sut = null;
-    let result = null;
     // When
     sut = new StaticsController(sendFile, options);
-    result = sut.getRoutes(router);
+    sut.addRoutes(router);
     // Then
-    expect(result).toEqual(options.files.map(() => route));
     expect(router.all).toHaveBeenCalledTimes(options.files.length);
     options.files.forEach((file) => {
       expect(router.all).toHaveBeenCalledWith(`/${file}`, [expect.any(Function)]);
@@ -168,23 +162,15 @@ describe('controllers/common:statics', () => {
         put: true,
       },
     };
-    const postRoute = 'post-route';
-    const putRoute = 'put-route';
     const router = {
-      post: jest.fn(() => postRoute),
-      put: jest.fn(() => putRoute),
+      post: jest.fn(() => router),
+      put: jest.fn(() => router),
     };
     let sut = null;
-    let result = null;
     // When
     sut = new StaticsController(sendFile, options);
-    result = sut.getRoutes(router);
+    sut.addRoutes(router);
     // Then
-    expect(result).toEqual(
-      options.files
-      .map(() => [postRoute, putRoute])
-      .reduce((acc, routes) => [...acc, ...routes], [])
-    );
     expect(router.post).toHaveBeenCalledTimes(options.files.length);
     expect(router.put).toHaveBeenCalledTimes(options.files.length);
     options.files.forEach((file) => {
@@ -200,17 +186,14 @@ describe('controllers/common:statics', () => {
       files: ['charito.html'],
     };
     const middlewares = ['middlewareOne', 'middlewareTwo'];
-    const route = 'route';
     const router = {
-      get: jest.fn(() => route),
+      get: jest.fn(() => router),
     };
     let sut = null;
-    let result = null;
     // When
     sut = new StaticsController(sendFile, options);
-    result = sut.getRoutes(router, middlewares);
+    sut.addRoutes(router, middlewares);
     // Then
-    expect(result).toEqual(options.files.map(() => route));
     expect(router.get).toHaveBeenCalledTimes(options.files.length);
     options.files.forEach((file) => {
       expect(router.get).toHaveBeenCalledWith(`/${file}`, [
@@ -227,9 +210,8 @@ describe('controllers/common:statics', () => {
     const options = {
       files: [file],
     };
-    const route = 'route';
     const router = {
-      get: jest.fn(() => route),
+      get: jest.fn(() => router),
     };
     const request = 'request';
     const response = {
@@ -240,7 +222,7 @@ describe('controllers/common:statics', () => {
     let middleware = null;
     // When
     sut = new StaticsController(sendFile, options);
-    sut.getRoutes(router);
+    sut.addRoutes(router);
     [[, [middleware]]] = router.get.mock.calls;
     middleware(request, response, next);
     // Then
@@ -260,9 +242,8 @@ describe('controllers/common:statics', () => {
         source: '../',
       },
     };
-    const route = 'route';
     const router = {
-      get: jest.fn(() => route),
+      get: jest.fn(() => router),
     };
     const request = 'request';
     const response = {
@@ -273,7 +254,7 @@ describe('controllers/common:statics', () => {
     let middleware = null;
     // When
     sut = new StaticsController(sendFile, options);
-    sut.getRoutes(router);
+    sut.addRoutes(router);
     [[, [middleware]]] = router.get.mock.calls;
     middleware(request, response, next);
     // Then
@@ -298,9 +279,8 @@ describe('controllers/common:statics', () => {
         route: '/statics',
       },
     };
-    const route = 'route';
     const router = {
-      get: jest.fn(() => route),
+      get: jest.fn(() => router),
     };
     const request = 'request';
     const response = {
@@ -311,7 +291,7 @@ describe('controllers/common:statics', () => {
     let middleware = null;
     // When
     sut = new StaticsController(sendFile, options);
-    sut.getRoutes(router);
+    sut.addRoutes(router);
     [[, [middleware]]] = router.get.mock.calls;
     middleware(request, response, next);
     // Then
@@ -344,9 +324,8 @@ describe('controllers/common:statics', () => {
         route: '/statics',
       },
     };
-    const route = 'route';
     const router = {
-      get: jest.fn(() => route),
+      get: jest.fn(() => router),
     };
     const request = 'request';
     const response = {
@@ -357,7 +336,7 @@ describe('controllers/common:statics', () => {
     let middleware = null;
     // When
     sut = new StaticsController(sendFile, options);
-    sut.getRoutes(router);
+    sut.addRoutes(router);
     [[, [middleware]]] = router.get.mock.calls;
     middleware(request, response, next);
     // Then
@@ -395,9 +374,8 @@ describe('controllers/common:statics', () => {
         route: '/statics',
       },
     };
-    const route = 'route';
     const router = {
-      get: jest.fn(() => route),
+      get: jest.fn(() => router),
     };
     const request = 'request';
     const response = {
@@ -412,7 +390,7 @@ describe('controllers/common:statics', () => {
     ];
     // When
     sut = new StaticsController(sendFile, options);
-    sut.getRoutes(router);
+    sut.addRoutes(router);
     [[, [middleware]]] = router.get.mock.calls;
     middleware(request, response, next);
     // Then
@@ -435,21 +413,26 @@ describe('controllers/common:statics', () => {
 
   it('should include a controller shorthand to return its routes', () => {
     // Given
+    const router = {
+      get: jest.fn(),
+    };
     const services = {
-      router: {
-        get: jest.fn((route, middlewaresList) => [`get:${route}`, middlewaresList]),
-      },
+      router,
     };
     const app = {
       get: jest.fn((service) => (services[service] || service)),
     };
-    let routes = null;
+    let result = null;
     const expectedGets = ['router', 'sendFile'];
     const expectedFiles = ['favicon.ico', 'index.html'];
     // When
-    routes = staticsController.connect(app);
+    result = staticsController.connect(app);
     // Then
-    expect(routes).toEqual(expectedFiles.map((file) => [`get:/${file}`, [expect.any(Function)]]));
+    expect(result).toBe(router);
+    expect(router.get).toHaveBeenCalledTimes(expectedFiles.length);
+    expectedFiles.forEach((file) => {
+      expect(router.get).toHaveBeenCalledWith(`/${file}`, [expect.any(Function)]);
+    });
     expect(app.get).toHaveBeenCalledTimes(expectedGets.length);
     expectedGets.forEach((service) => {
       expect(app.get).toHaveBeenCalledWith(service);
@@ -468,26 +451,28 @@ describe('controllers/common:statics', () => {
     };
     const middlewares = [normalMiddleware, jimpexMiddleware];
     const middlewareGenerator = jest.fn(() => middlewares);
+    const router = {
+      get: jest.fn(),
+    };
     const services = {
-      router: {
-        get: jest.fn((route, middlewaresList) => [`get:${route}`, middlewaresList]),
-      },
+      router,
     };
     const app = {
       get: jest.fn((service) => (services[service] || service)),
     };
-    let routes = null;
+    let result = null;
     const expectedGets = ['router', 'sendFile'];
     // When
-    routes = staticsController(options, middlewareGenerator).connect(app);
+    result = staticsController(options, middlewareGenerator).connect(app);
     // Then
-    expect(routes).toEqual(options.files.map((file) => [
-      `get:/${file}`,
-      [
+    expect(result).toBe(router);
+    expect(router.get).toHaveBeenCalledTimes(options.files.length);
+    options.files.forEach((file) => {
+      expect(router.get).toHaveBeenCalledWith(`/${file}`, [
         ...[normalMiddleware, jimpexMiddlewareName],
         expect.any(Function),
-      ],
-    ]));
+      ]);
+    });
     expect(middlewareGenerator).toHaveBeenCalledTimes(1);
     expect(middlewareGenerator).toHaveBeenCalledWith(app);
     expect(jimpexMiddleware.connect).toHaveBeenCalledTimes(1);

--- a/tests/controllers/index.test.js
+++ b/tests/controllers/index.test.js
@@ -9,6 +9,7 @@ describe('controllers', () => {
     // Given
     const knownControllers = [
       'common',
+      'utils',
     ];
     // When/Then
     expect(Object.keys(controllers).length).toBe(knownControllers.length);

--- a/tests/controllers/utils/gateway.test.js
+++ b/tests/controllers/utils/gateway.test.js
@@ -1,0 +1,1269 @@
+jest.unmock('/src/utils/functions');
+jest.unmock('/src/utils/wrappers');
+jest.unmock('/src/controllers/utils/gateway');
+
+const statuses = require('statuses');
+require('jasmine-expect');
+const {
+  GatewayController,
+  gatewayController,
+} = require('/src/controllers/utils/gateway');
+
+describe('controllers/utils:gateway', () => {
+  describe('instance', () => {
+    it('should be instantiated with its default options', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {},
+      };
+      const route = '/my-gateway';
+      const http = 'http';
+      let sut = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http);
+      // Then
+      expect(sut).toBeInstanceOf(GatewayController);
+      expect(sut.addRoutes).toBeFunction();
+      expect(sut.gatewayConfig).toEqual(gatewayConfig);
+      expect(sut.options).toEqual({
+        root: '',
+        configurationSetting: 'api',
+        headers: {
+          useXForwardedFor: true,
+          copyCustomHeaders: true,
+          copy: [
+            'authorization',
+            'content-type',
+            'referer',
+            'user-agent',
+          ],
+          remove: [
+            'server',
+            'x-powered-by',
+          ],
+        },
+      });
+    });
+
+    it('should be instantiated with custom options', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {},
+      };
+      const route = '/my-gateway';
+      const http = 'http';
+      const options = {
+        root: 'my-root',
+        configurationSetting: 'myApi',
+        headers: {
+          useXForwardedFor: false,
+          copyCustomHeaders: false,
+          copy: ['authorization'],
+          remove: ['x-powered-by'],
+        },
+      };
+      let sut = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options);
+      // Then
+      expect(sut).toBeInstanceOf(GatewayController);
+      expect(sut.options).toEqual(options);
+    });
+
+    it('should throw an error when two endpoints share the same path and method', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path',
+          endpointTwo: '/my-path',
+        },
+      };
+      const route = '/my-gateway';
+      const http = 'http';
+      // When/Then
+      expect(() => new GatewayController(gatewayConfig, route, http))
+      .toThrow(/You can't have two gateway endpoints to the same path/i);
+    });
+
+    it('should create a configuration for an API client', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path/one',
+          endpointTwo: {
+            path: '/my-path/two',
+          },
+        },
+      };
+      const route = '/my-gateway';
+      const http = 'http';
+      let sut = null;
+      let result = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http);
+      result = sut.endpointsForAPIClient;
+      // Then
+      expect(result).toEqual({
+        url: route,
+        endpoints: {
+          [sut.options.configurationSetting]: gatewayConfig.gateway,
+        },
+      });
+    });
+
+    it('should create a configuration for an API client with a custom root', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path/one',
+          endpointTwo: {
+            path: '/my-path/two',
+          },
+        },
+      };
+      const route = '/my-gateway';
+      const http = 'http';
+      const root = 'my-root';
+      const configurationSetting = 'myRootedAPI';
+      const options = {
+        root,
+        configurationSetting,
+      };
+      let sut = null;
+      let result = null;
+      const expectedEndpoints = {
+        endpointOne: `${root}${gatewayConfig.gateway.endpointOne}`,
+        endpointTwo: {
+          path: `${root}${gatewayConfig.gateway.endpointTwo.path}`,
+        },
+      };
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options);
+      result = sut.endpointsForAPIClient;
+      // Then
+      expect(result).toEqual({
+        url: route,
+        endpoints: {
+          [configurationSetting]: expectedEndpoints,
+        },
+      });
+    });
+
+    it('should add the gateway routes to the router', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path/one',
+          endpointTwo: {
+            path: '/my-path/two',
+            method: 'post',
+          },
+        },
+      };
+      const route = '/my-gateway';
+      const http = 'http';
+      const router = {
+        all: jest.fn(),
+        post: jest.fn(),
+      };
+      let sut = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http);
+      sut.addRoutes(router);
+      // Then
+      expect(router.all).toHaveBeenCalledTimes(1);
+      expect(router.all).toHaveBeenCalledWith(gatewayConfig.gateway.endpointOne.substr(1), [
+        expect.any(Function),
+      ]);
+      expect(router.post).toHaveBeenCalledTimes(1);
+      expect(router.post).toHaveBeenCalledWith(
+        gatewayConfig.gateway.endpointTwo.path.substr(1),
+        [expect.any(Function)]
+      );
+    });
+
+    it('should add the gateway routes to the router with a custom middleware', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path/one',
+          endpointTwo: {
+            path: '/my-path/two',
+            method: 'post',
+          },
+        },
+      };
+      const route = '/my-gateway';
+      const http = 'http';
+      const middleware = 'my-middleware';
+      const router = {
+        all: jest.fn(),
+        post: jest.fn(),
+      };
+      let sut = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http);
+      sut.addRoutes(router, [middleware]);
+      // Then
+      expect(router.all).toHaveBeenCalledTimes(1);
+      expect(router.all).toHaveBeenCalledWith(gatewayConfig.gateway.endpointOne.substr(1), [
+        middleware,
+        expect.any(Function),
+      ]);
+      expect(router.post).toHaveBeenCalledTimes(1);
+      expect(router.post).toHaveBeenCalledWith(
+        gatewayConfig.gateway.endpointTwo.path.substr(1),
+        [
+          middleware,
+          expect.any(Function),
+        ]
+      );
+    });
+
+    it('should use `all` when an endpoint doesn\'t have a valid HTTP method', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: {
+            path: '/my-path/one',
+            method: 'myCosmicMethod',
+          },
+        },
+      };
+      const route = '/my-gateway';
+      const http = 'http';
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http);
+      sut.addRoutes(router);
+      // Then
+      expect(router.all).toHaveBeenCalledTimes(1);
+      expect(router.all).toHaveBeenCalledWith(
+        gatewayConfig.gateway.endpointOne.path.substr(1),
+        [expect.any(Function)]
+      );
+    });
+  });
+
+  describe('middleware', () => {
+    it('should stream a gateway request response', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const httpResponse = {
+        status: statuses.ok,
+        body: {
+          pipe: jest.fn(() => httpResponse.body),
+          on: jest.fn(),
+        },
+        headers: [
+          'content-type',
+          'server',
+        ],
+      };
+      const ip = '25.09.2015';
+      const customHeaderName = 'x-custom-header';
+      const customHeaderValue = 'my-custom-header-value';
+      const http = {
+        fetch: jest.fn(() => Promise.resolve(httpResponse)),
+        getIPFromRequest: jest.fn(() => ip),
+        getCustomHeadersFromRequest: jest.fn(() => ({
+          [customHeaderName]: customHeaderValue,
+        })),
+      };
+      const options = {
+        headers: {
+          // This is stupid, but the iterator for headers goes `value, name`.
+          remove: [1],
+        },
+      };
+      const headerToCopy = 'authorization';
+      const headerToCopyValue = 'bearer abc';
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'GET',
+        headers: {
+          [headerToCopy]: [headerToCopyValue],
+        },
+      };
+      const response = {
+        status: jest.fn(),
+        setHeader: jest.fn(),
+      };
+      const next = 'next';
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      let middleware = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        // Then
+        expect(http.getCustomHeadersFromRequest).toHaveBeenCalledTimes(1);
+        expect(http.getCustomHeadersFromRequest).toHaveBeenCalledWith(request);
+        expect(http.getIPFromRequest).toHaveBeenCalledTimes(1);
+        expect(http.getIPFromRequest).toHaveBeenCalledWith(request);
+        expect(http.fetch).toHaveBeenCalledTimes(1);
+        expect(http.fetch).toHaveBeenCalledWith(
+          `${gatewayConfig.url}/${gatewayConfig.gateway.endpointOne}`,
+          {
+            method: request.method,
+            headers: {
+              [headerToCopy]: [headerToCopyValue],
+              [customHeaderName]: customHeaderValue,
+              'x-forwarded-for': ip,
+            },
+          }
+        );
+        expect(response.status).toHaveBeenCalledTimes(1);
+        expect(response.status).toHaveBeenCalledWith(httpResponse.status);
+        expect(response.setHeader).toHaveBeenCalledTimes(1);
+        expect(response.setHeader).toHaveBeenCalledWith(0, httpResponse.headers[0]);
+        expect(httpResponse.body.pipe).toHaveBeenCalledTimes(1);
+        expect(httpResponse.body.pipe).toHaveBeenCalledWith(response);
+        expect(httpResponse.body.on).toHaveBeenCalledTimes(1);
+        expect(httpResponse.body.on).toHaveBeenCalledWith('error', expect.any(Function));
+      });
+    });
+
+    it('shouldn\'t add custom headers to the request', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const httpResponse = {
+        status: statuses.ok,
+        body: {
+          pipe: jest.fn(() => httpResponse.body),
+          on: jest.fn(),
+        },
+        headers: [
+          'content-type',
+          'server',
+        ],
+      };
+      const http = {
+        fetch: jest.fn(() => Promise.resolve(httpResponse)),
+        getIPFromRequest: jest.fn(),
+        getCustomHeadersFromRequest: jest.fn(),
+      };
+      const options = {
+        headers: {
+          useXForwardedFor: false,
+          copyCustomHeaders: false,
+        },
+      };
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'GET',
+        headers: {},
+      };
+      const response = {
+        status: jest.fn(),
+        setHeader: jest.fn(),
+      };
+      const next = 'next';
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      let middleware = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        // Then
+        expect(http.getCustomHeadersFromRequest).toHaveBeenCalledTimes(0);
+        expect(http.getIPFromRequest).toHaveBeenCalledTimes(0);
+        expect(http.fetch).toHaveBeenCalledTimes(1);
+        expect(http.fetch).toHaveBeenCalledWith(
+          `${gatewayConfig.url}/${gatewayConfig.gateway.endpointOne}`,
+          {
+            method: request.method,
+            headers: {},
+          }
+        );
+      });
+    });
+
+    it('should stream a gateway request that includes a body', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const httpResponse = {
+        status: statuses.ok,
+        body: {
+          pipe: jest.fn(() => httpResponse.body),
+          on: jest.fn(),
+        },
+        headers: [],
+      };
+      const http = {
+        fetch: jest.fn(() => Promise.resolve(httpResponse)),
+      };
+      const options = {
+        headers: {
+          useXForwardedFor: false,
+          copyCustomHeaders: false,
+        },
+      };
+      const headerToCopy = 'content-type';
+      const headerToCopyValue = 'application/json';
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'POST',
+        headers: {
+          [headerToCopy]: [headerToCopyValue],
+        },
+        body: {
+          myProp: 'myValue',
+        },
+      };
+      const response = {
+        status: jest.fn(),
+      };
+      const next = 'next';
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      let middleware = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        // Then
+        expect(http.fetch).toHaveBeenCalledTimes(1);
+        expect(http.fetch).toHaveBeenCalledWith(
+          `${gatewayConfig.url}/${gatewayConfig.gateway.endpointOne}`,
+          {
+            method: request.method,
+            headers: {
+              [headerToCopy]: [headerToCopyValue],
+            },
+            body: JSON.stringify(request.body),
+          }
+        );
+      });
+    });
+
+    it('should add the content type for JSON when there\'s a body but no header', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const httpResponse = {
+        status: statuses.ok,
+        body: {
+          pipe: jest.fn(() => httpResponse.body),
+          on: jest.fn(),
+        },
+        headers: [],
+      };
+      const http = {
+        fetch: jest.fn(() => Promise.resolve(httpResponse)),
+      };
+      const options = {
+        headers: {
+          useXForwardedFor: false,
+          copyCustomHeaders: false,
+        },
+      };
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'POST',
+        headers: {},
+        body: {
+          myProp: 'myValue',
+        },
+      };
+      const response = {
+        status: jest.fn(),
+      };
+      const next = 'next';
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      let middleware = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        // Then
+        expect(http.fetch).toHaveBeenCalledTimes(1);
+        expect(http.fetch).toHaveBeenCalledWith(
+          `${gatewayConfig.url}/${gatewayConfig.gateway.endpointOne}`,
+          {
+            method: request.method,
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify(request.body),
+          }
+        );
+      });
+    });
+
+    it('should call the next middleware if the streaming fails', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const httpResponse = {
+        status: statuses.ok,
+        body: {
+          pipe: jest.fn(() => httpResponse.body),
+          on: jest.fn(),
+        },
+        headers: [],
+      };
+      const http = {
+        fetch: jest.fn(() => Promise.resolve(httpResponse)),
+      };
+      const options = {
+        headers: {
+          useXForwardedFor: false,
+          copyCustomHeaders: false,
+        },
+      };
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'POST',
+        headers: {},
+        body: {
+          myProp: 'myValue',
+        },
+      };
+      const response = {
+        status: jest.fn(),
+      };
+      const next = jest.fn();
+      const router = {
+        all: jest.fn(),
+      };
+      const error = new Error('MyError');
+      let sut = null;
+      let middleware = null;
+      let onError = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        [[, onError]] = httpResponse.body.on.mock.calls;
+        onError(error);
+        // Then
+        expect(http.fetch).toHaveBeenCalledTimes(1);
+        expect(http.fetch).toHaveBeenCalledWith(
+          `${gatewayConfig.url}/${gatewayConfig.gateway.endpointOne}`,
+          {
+            method: request.method,
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify(request.body),
+          }
+        );
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledWith(error);
+      });
+    });
+
+    it('should call the next middleware if the request fails', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const error = new Error('MyError');
+      const http = {
+        fetch: jest.fn(() => Promise.reject(error)),
+      };
+      const options = {
+        headers: {
+          useXForwardedFor: false,
+          copyCustomHeaders: false,
+        },
+      };
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'POST',
+        headers: {},
+        body: {
+          myProp: 'myValue',
+        },
+      };
+      const response = {
+        status: jest.fn(),
+      };
+      const next = jest.fn();
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      let middleware = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        // Then
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledWith(error);
+      });
+    });
+  });
+
+  describe('middleware with helper', () => {
+    it('should be able to modify the request', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const httpResponse = {
+        status: statuses.ok,
+        body: {
+          pipe: jest.fn(() => httpResponse.body),
+          on: jest.fn(),
+        },
+        headers: [
+          'content-type',
+          'server',
+        ],
+      };
+      const ip = '25.09.2015';
+      const customHeaderName = 'x-custom-header';
+      const customHeaderValue = 'my-custom-header-value';
+      const http = {
+        fetch: jest.fn(() => Promise.resolve(httpResponse)),
+        getIPFromRequest: jest.fn(() => ip),
+        getCustomHeadersFromRequest: jest.fn(() => ({
+          [customHeaderName]: customHeaderValue,
+        })),
+      };
+      const options = {
+        headers: {
+          // This is stupid, but the iterator for headers goes `value, name`.
+          remove: [1],
+        },
+      };
+      const helper = {
+        reduceEndpointRequest: jest.fn((request) => Object.assign({}, request, {
+          url: `${request.url}-by-helper`,
+          options: request.options,
+        })),
+      };
+      const headerToCopy = 'authorization';
+      const headerToCopyValue = 'bearer abc';
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'GET',
+        headers: {
+          [headerToCopy]: [headerToCopyValue],
+        },
+      };
+      const response = {
+        status: jest.fn(),
+        setHeader: jest.fn(),
+      };
+      const next = 'next';
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      let middleware = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options, helper);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        // Then
+        expect(http.getCustomHeadersFromRequest).toHaveBeenCalledTimes(1);
+        expect(http.getCustomHeadersFromRequest).toHaveBeenCalledWith(request);
+        expect(http.getIPFromRequest).toHaveBeenCalledTimes(1);
+        expect(http.getIPFromRequest).toHaveBeenCalledWith(request);
+        expect(helper.reduceEndpointRequest).toHaveBeenCalledTimes(1);
+        expect(helper.reduceEndpointRequest).toHaveBeenCalledWith(
+          {
+            url: `${gatewayConfig.url}/${gatewayConfig.gateway.endpointOne}`,
+            options: {
+              method: request.method,
+              headers: {
+                [headerToCopy]: [headerToCopyValue],
+                [customHeaderName]: customHeaderValue,
+                'x-forwarded-for': ip,
+              },
+            },
+          },
+          {
+            name: 'endpointOne',
+            settings: gatewayConfig.gateway.endpointOne,
+          },
+          request,
+          response,
+          next
+        );
+        expect(http.fetch).toHaveBeenCalledTimes(1);
+        expect(http.fetch).toHaveBeenCalledWith(
+          `${gatewayConfig.url}/${gatewayConfig.gateway.endpointOne}-by-helper`,
+          {
+            method: request.method,
+            headers: {
+              [headerToCopy]: [headerToCopyValue],
+              [customHeaderName]: customHeaderValue,
+              'x-forwarded-for': ip,
+            },
+          }
+        );
+        expect(response.status).toHaveBeenCalledTimes(1);
+        expect(response.status).toHaveBeenCalledWith(httpResponse.status);
+        expect(response.setHeader).toHaveBeenCalledTimes(1);
+        expect(response.setHeader).toHaveBeenCalledWith(0, httpResponse.headers[0]);
+        expect(httpResponse.body.pipe).toHaveBeenCalledTimes(1);
+        expect(httpResponse.body.pipe).toHaveBeenCalledWith(response);
+        expect(httpResponse.body.on).toHaveBeenCalledTimes(1);
+        expect(httpResponse.body.on).toHaveBeenCalledWith('error', expect.any(Function));
+      });
+    });
+
+    it('should be able to modify the response', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const httpResponse = {
+        status: statuses.ok,
+        body: {
+          pipe: jest.fn(() => httpResponse.body),
+          on: jest.fn(),
+        },
+        headers: [
+          'content-type',
+          'server',
+        ],
+      };
+      const http = {
+        fetch: jest.fn(() => Promise.resolve(httpResponse)),
+      };
+      const options = {
+        headers: {
+          useXForwardedFor: false,
+          copyCustomHeaders: false,
+        },
+      };
+      const helper = {
+        reduceEndpointResponse: jest.fn((response) => Object.assign({}, response, {
+          status: statuses.conflict,
+        })),
+      };
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'GET',
+        headers: {},
+      };
+      const response = {
+        status: jest.fn(),
+        setHeader: jest.fn(),
+      };
+      const next = 'next';
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      let middleware = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options, helper);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        // Then
+        expect(helper.reduceEndpointResponse).toHaveBeenCalledTimes(1);
+        expect(helper.reduceEndpointResponse).toHaveBeenCalledWith(
+          httpResponse,
+          {
+            name: 'endpointOne',
+            settings: gatewayConfig.gateway.endpointOne,
+          },
+          request,
+          response,
+          next
+        );
+        expect(response.status).toHaveBeenCalledTimes(1);
+        expect(response.status).toHaveBeenCalledWith(statuses.conflict);
+      });
+    });
+
+    it('should be able to handle the response', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const httpResponse = {
+        status: statuses.ok,
+        body: {
+          pipe: jest.fn(() => httpResponse.body),
+          on: jest.fn(),
+        },
+        headers: [
+          'content-type',
+          'server',
+        ],
+      };
+      const http = {
+        fetch: jest.fn(() => Promise.resolve(httpResponse)),
+      };
+      const options = {
+        headers: {
+          useXForwardedFor: false,
+          copyCustomHeaders: false,
+        },
+      };
+      const helper = {
+        shouldStreamEndpointResponse: jest.fn(() => false),
+        handleEndpointResponse: jest.fn(),
+      };
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'GET',
+        headers: {},
+      };
+      const response = {
+        status: jest.fn(),
+        setHeader: jest.fn(),
+      };
+      const next = 'next';
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      let middleware = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options, helper);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        // Then
+        expect(helper.shouldStreamEndpointResponse).toHaveBeenCalledTimes(1);
+        expect(helper.shouldStreamEndpointResponse).toHaveBeenCalledWith(
+          httpResponse,
+          {
+            name: 'endpointOne',
+            settings: gatewayConfig.gateway.endpointOne,
+          },
+          request,
+          response,
+          next
+        );
+        expect(helper.handleEndpointResponse).toHaveBeenCalledTimes(1);
+        expect(helper.handleEndpointResponse).toHaveBeenCalledWith(
+          httpResponse,
+          {
+            name: 'endpointOne',
+            settings: gatewayConfig.gateway.endpointOne,
+          },
+          request,
+          response,
+          next
+        );
+      });
+    });
+
+    it('should be able to handle an error', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: 'my-path-one',
+        },
+      };
+      const route = '/my-gateway';
+      const error = new Error('MyError');
+      const http = {
+        fetch: jest.fn(() => Promise.reject(error)),
+      };
+      const options = {
+        headers: {
+          useXForwardedFor: false,
+          copyCustomHeaders: false,
+        },
+      };
+      const helper = {
+        handleEndpointError: jest.fn(),
+      };
+      const request = {
+        originalUrl: `${route}/${gatewayConfig.gateway.endpointOne}`,
+        method: 'POST',
+        headers: {},
+        body: {
+          myProp: 'myValue',
+        },
+      };
+      const response = {
+        status: jest.fn(),
+      };
+      const next = jest.fn();
+      const router = {
+        all: jest.fn(),
+      };
+      let sut = null;
+      let middleware = null;
+      // When
+      sut = new GatewayController(gatewayConfig, route, http, options, helper);
+      sut.addRoutes(router);
+      [[, [middleware]]] = router.all.mock.calls;
+      return middleware(request, response, next)
+      .then(() => {
+        // Then
+        expect(helper.handleEndpointError).toHaveBeenCalledTimes(1);
+        expect(helper.handleEndpointError).toHaveBeenCalledWith(
+          error,
+          {
+            name: 'endpointOne',
+            settings: gatewayConfig.gateway.endpointOne,
+          },
+          request,
+          response,
+          next
+        );
+      });
+    });
+  });
+
+  describe('shorthand', () => {
+    it('should register the routes and return the router', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path/one',
+        },
+      };
+      const appConfiguration = {
+        get: jest.fn(() => gatewayConfig),
+      };
+      const router = {
+        all: jest.fn(),
+      };
+      const services = {
+        appConfiguration,
+        router,
+      };
+      const app = {
+        get: jest.fn((name) => services[name] || name),
+        set: jest.fn(),
+        try: jest.fn(),
+      };
+      let result = null;
+      let service = null;
+      const expectedGetServices = [
+        'appConfiguration',
+        'http',
+        'router',
+      ];
+      // When
+      result = gatewayController.connect(app);
+      [[, service]] = app.set.mock.calls;
+      // Then
+      expect(result).toBe(router);
+      expect(router.all).toHaveBeenCalledTimes(1);
+      expect(router.all).toHaveBeenCalledWith(gatewayConfig.gateway.endpointOne.substr(1), [
+        expect.any(Function),
+      ]);
+      expect(appConfiguration.get).toHaveBeenCalledTimes(1);
+      expect(appConfiguration.get).toHaveBeenCalledWith('api');
+      expect(app.get).toHaveBeenCalledTimes(expectedGetServices.length);
+      expectedGetServices.forEach((name) => {
+        expect(app.get).toHaveBeenCalledWith(name);
+      });
+      expect(app.try).toHaveBeenCalledTimes(1);
+      expect(app.try).toHaveBeenCalledWith('apiGatewayHelper');
+      expect(app.set).toHaveBeenCalledTimes(1);
+      expect(app.set).toHaveBeenCalledWith('apiGateway', expect.any(Function));
+      expect(service).toBeFunction();
+      expect(service()).toBeInstanceOf(GatewayController);
+    });
+
+    it('should be created with a custom name', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path/one',
+        },
+      };
+      const appConfiguration = {
+        get: jest.fn(() => gatewayConfig),
+      };
+      const router = {
+        all: jest.fn(),
+      };
+      const services = {
+        appConfiguration,
+        router,
+      };
+      const app = {
+        get: jest.fn((name) => services[name] || name),
+        set: jest.fn(),
+        try: jest.fn(),
+      };
+      let result = null;
+      let service = null;
+      const expectedGetServices = [
+        'appConfiguration',
+        'http',
+        'router',
+      ];
+      const options = {
+        serviceName: 'myService',
+      };
+      // When
+      result = gatewayController(options).connect(app);
+      [[, service]] = app.set.mock.calls;
+      // Then
+      expect(result).toBe(router);
+      expect(router.all).toHaveBeenCalledTimes(1);
+      expect(router.all).toHaveBeenCalledWith(gatewayConfig.gateway.endpointOne.substr(1), [
+        expect.any(Function),
+      ]);
+      expect(appConfiguration.get).toHaveBeenCalledTimes(1);
+      expect(appConfiguration.get).toHaveBeenCalledWith(options.serviceName);
+      expect(app.get).toHaveBeenCalledTimes(expectedGetServices.length);
+      expectedGetServices.forEach((name) => {
+        expect(app.get).toHaveBeenCalledWith(name);
+      });
+      expect(app.try).toHaveBeenCalledTimes(1);
+      expect(app.try).toHaveBeenCalledWith(`${options.serviceName}GatewayHelper`);
+      expect(app.set).toHaveBeenCalledTimes(1);
+      expect(app.set).toHaveBeenCalledWith(`${options.serviceName}Gateway`, expect.any(Function));
+      expect(service).toBeFunction();
+      expect(service()).toBeInstanceOf(GatewayController);
+    });
+
+    it('should be created with a custom name, custom setting and custom helper name', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path/one',
+        },
+      };
+      const appConfiguration = {
+        get: jest.fn(() => gatewayConfig),
+      };
+      const router = {
+        all: jest.fn(),
+      };
+      const services = {
+        appConfiguration,
+        router,
+      };
+      const app = {
+        get: jest.fn((name) => services[name] || name),
+        set: jest.fn(),
+        try: jest.fn(),
+      };
+      let result = null;
+      let service = null;
+      const expectedGetServices = [
+        'appConfiguration',
+        'http',
+        'router',
+      ];
+      const options = {
+        serviceName: 'myServiceGateway',
+        configurationSetting: 'myConfigSetting',
+        helperServiceName: 'myGatewayHelper',
+      };
+      // When
+      result = gatewayController(options).connect(app);
+      [[, service]] = app.set.mock.calls;
+      // Then
+      expect(result).toBe(router);
+      expect(router.all).toHaveBeenCalledTimes(1);
+      expect(router.all).toHaveBeenCalledWith(gatewayConfig.gateway.endpointOne.substr(1), [
+        expect.any(Function),
+      ]);
+      expect(appConfiguration.get).toHaveBeenCalledTimes(1);
+      expect(appConfiguration.get).toHaveBeenCalledWith(options.configurationSetting);
+      expect(app.get).toHaveBeenCalledTimes(expectedGetServices.length);
+      expectedGetServices.forEach((name) => {
+        expect(app.get).toHaveBeenCalledWith(name);
+      });
+      expect(app.try).toHaveBeenCalledTimes(1);
+      expect(app.try).toHaveBeenCalledWith(options.helperServiceName);
+      expect(app.set).toHaveBeenCalledTimes(1);
+      expect(app.set).toHaveBeenCalledWith(options.serviceName, expect.any(Function));
+      expect(service).toBeFunction();
+      expect(service()).toBeInstanceOf(GatewayController);
+    });
+
+    it('should be created without a helper service', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path/one',
+        },
+      };
+      const appConfiguration = {
+        get: jest.fn(() => gatewayConfig),
+      };
+      const router = {
+        all: jest.fn(),
+      };
+      const services = {
+        appConfiguration,
+        router,
+      };
+      const app = {
+        get: jest.fn((name) => services[name] || name),
+        set: jest.fn(),
+        try: jest.fn(),
+      };
+      let result = null;
+      let service = null;
+      const expectedGetServices = [
+        'appConfiguration',
+        'http',
+        'router',
+      ];
+      const options = {
+        serviceName: 'myServiceGateway',
+        configurationSetting: 'myConfigSetting',
+        helperServiceName: null,
+      };
+      // When
+      result = gatewayController(options).connect(app);
+      [[, service]] = app.set.mock.calls;
+      // Then
+      expect(result).toBe(router);
+      expect(router.all).toHaveBeenCalledTimes(1);
+      expect(router.all).toHaveBeenCalledWith(gatewayConfig.gateway.endpointOne.substr(1), [
+        expect.any(Function),
+      ]);
+      expect(appConfiguration.get).toHaveBeenCalledTimes(1);
+      expect(appConfiguration.get).toHaveBeenCalledWith(options.configurationSetting);
+      expect(app.get).toHaveBeenCalledTimes(expectedGetServices.length);
+      expectedGetServices.forEach((name) => {
+        expect(app.get).toHaveBeenCalledWith(name);
+      });
+      expect(app.try).toHaveBeenCalledTimes(0);
+      expect(app.set).toHaveBeenCalledTimes(1);
+      expect(app.set).toHaveBeenCalledWith(options.serviceName, expect.any(Function));
+      expect(service).toBeFunction();
+      expect(service()).toBeInstanceOf(GatewayController);
+    });
+
+    it('should be created with custom middlewares', () => {
+      // Given
+      const gatewayConfig = {
+        url: 'http://my-api.com',
+        gateway: {
+          endpointOne: '/my-path/one',
+        },
+      };
+      const appConfiguration = {
+        get: jest.fn(() => gatewayConfig),
+      };
+      const router = {
+        all: jest.fn(),
+      };
+      const services = {
+        appConfiguration,
+        router,
+      };
+      const app = {
+        get: jest.fn((name) => services[name] || name),
+        set: jest.fn(),
+        try: jest.fn(),
+      };
+      let result = null;
+      const options = {
+        serviceName: 'myServiceGateway',
+        configurationSetting: 'myConfigSetting',
+        helperServiceName: null,
+      };
+      const normalMiddleware = 'middlewareOne';
+      const jimpexMiddlewareName = 'middlewareTwo';
+      const jimpexMiddleware = {
+        connect: jest.fn(() => jimpexMiddlewareName),
+      };
+      const middlewares = [normalMiddleware, jimpexMiddleware];
+      const middlewareGenerator = jest.fn(() => middlewares);
+      // When
+      result = gatewayController(options, middlewareGenerator).connect(app);
+      // Then
+      expect(result).toBe(router);
+      expect(router.all).toHaveBeenCalledTimes(1);
+      expect(router.all).toHaveBeenCalledWith(gatewayConfig.gateway.endpointOne.substr(1), [
+        normalMiddleware,
+        jimpexMiddlewareName,
+        expect.any(Function),
+      ]);
+    });
+  });
+});

--- a/tests/middlewares/html/fastHTML.test.js
+++ b/tests/middlewares/html/fastHTML.test.js
@@ -1,3 +1,4 @@
+jest.unmock('/src/utils/functions');
 jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/middlewares/html/fastHTML');
 

--- a/tests/utils/functions.test.js
+++ b/tests/utils/functions.test.js
@@ -1,0 +1,161 @@
+jest.unmock('/src/utils/functions');
+
+require('jasmine-expect');
+const {
+  createRouteExpression,
+  escapeForRegExp,
+  removeLeadingSlash,
+  removeSlashes,
+  removeTrailingSlash,
+} = require('/src/utils/functions');
+
+describe('utils/functions', () => {
+  describe('removeLeadingSlash', () => {
+    it('should remove the leading slash from a URL', () => {
+      // Given
+      const url = '/my/url';
+      let result = null;
+      // When
+      result = removeLeadingSlash(url);
+      // Then
+      expect(result).toBe(url.substr(1));
+    });
+
+    it('should remove multiple leading slashes from a URL', () => {
+      // Given
+      const url = '///my/url';
+      let result = null;
+      // When
+      result = removeLeadingSlash(url);
+      // Then
+      expect(result).toBe(url.substr(3));
+    });
+
+    it('shouldn\'t modify a URL that doesn\'t start with a slash', () => {
+      // Given
+      const url = 'my/url';
+      let result = null;
+      // When
+      result = removeLeadingSlash(url);
+      // Then
+      expect(result).toBe(url);
+    });
+  });
+
+  describe('removeTrailingSlash', () => {
+    it('should remove the leading slash from a URL', () => {
+      // Given
+      const url = 'my/url/';
+      let result = null;
+      // When
+      result = removeTrailingSlash(url);
+      // Then
+      expect(result).toBe(url.substr(0, url.length - 1));
+    });
+
+    it('should remove multiple trailing slashes from a URL', () => {
+      // Given
+      const url = 'my/url///';
+      let result = null;
+      // When
+      result = removeTrailingSlash(url);
+      // Then
+      expect(result).toBe(url.substr(0, url.length - 3));
+    });
+
+    it('shouldn\'t modify a URL that doesn\'t start with a slash', () => {
+      // Given
+      const url = 'my/url';
+      let result = null;
+      // When
+      result = removeTrailingSlash(url);
+      // Then
+      expect(result).toBe(url);
+    });
+  });
+
+  describe('removeSlashes', () => {
+    it('should remove both leading and trailing slashes from a URL', () => {
+      // Given
+      const url = '/my/url/';
+      let result = null;
+      // When
+      result = removeSlashes(url);
+      // Then
+      expect(result).toBe(url.substr(1, url.length - 2));
+    });
+
+    it('should remove the trailing slash from a URL', () => {
+      // Given
+      const url = '/my/url/';
+      let result = null;
+      // When
+      result = removeSlashes(url, false);
+      // Then
+      expect(result).toBe(url.substr(0, url.length - 1));
+    });
+
+    it('shouldn\'t remove slashes from a URL', () => {
+      // Given
+      const url = '/my/url/';
+      let result = null;
+      // When
+      result = removeSlashes(url, false, false);
+      // Then
+      expect(result).toBe(url);
+    });
+  });
+
+  describe('escapeForRegExp', () => {
+    it('should escape a text to be used inside a RegExp', () => {
+      // Given
+      const text = 'hello {(world)}';
+      let result = null;
+      // When
+      result = escapeForRegExp(text);
+      // Then
+      expect(result).toBe('hello\\ \\{\\(world\\)\\}');
+    });
+  });
+
+  describe('createRouteExpression', () => {
+    it('should create a expression that matches a route', () => {
+      // Given
+      const definition = '/my-route/:my-param/something/:else/end';
+      const route = '/my-route/something/something/something/end';
+      let expression = null;
+      let result = null;
+      // When
+      expression = createRouteExpression(definition);
+      result = expression.test(route);
+      // Then
+      expect(result).toBeTrue();
+    });
+
+    it('should create a expression that matches the route with a trailing slash', () => {
+      // Given
+      const definition = '/my-route/:my-param/something/:else/end';
+      const route = 'my-route/something/something/something/end/';
+      let expression = null;
+      let result = null;
+      // When
+      expression = createRouteExpression(definition, false, true);
+      result = expression.test(route);
+      // Then
+      expect(result).toBeTrue();
+    });
+
+    it('should create a expression that doesn\'t matches a route', () => {
+      // Given
+      const definition = '/my-route/:my-param/something/:else/end';
+      const route = '/my-route/something/something/something';
+      let expression = null;
+      let result = null;
+      // When
+      expression = createRouteExpression(definition);
+      result = expression.test(route);
+      // Then
+      expect(result).toBeFalse();
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

It adds a new controller: The gateway controller.

This new controller allows you to define a gateway on your app configuration, and then it will take care of mounting routes that when navigated will make requests and stream down the response.

Please read the updated documentation included on this PR to better understand the controller.

Two minor things I did on this PR:

- I modified the Statics controller so it will register the router and not the set of routes.
- I added a `utils/functions` file with a couple of functions that a few services were re declaring.

**This is breaking for things that haven't been released yet**, that's why it's marked as `feature`.

### How should it be tested manually?

Follow the example of the documentation, define a gateway and test if the requests are being made when you navigate its routes.

Also...

```bash
yarn test
# or
npm test
```
