### PR TITLE
feat: use 'gateway' if 'endpoints' is not avaiable on the APIClient

### DIFF
--- a/src/services/http/apiClient.js
+++ b/src/services/http/apiClient.js
@@ -35,7 +35,11 @@ class APIClient extends APIClientBase {
    * @param {Class}                  HTTPError To format the received errors.
    */
   constructor(apiConfig, http, HTTPError) {
-    super(apiConfig.url, apiConfig.endpoints, http.fetch);
+    super(
+      apiConfig.url,
+      apiConfig.endpoints || apiConfig.gateway,
+      http.fetch
+    );
     /**
      * The configuration for the API the client will make requests to.
      * @type {APIClientConfiguration}

--- a/tests/services/http/apiClient.test.js
+++ b/tests/services/http/apiClient.test.js
@@ -32,6 +32,30 @@ describe('services/http:client', () => {
     expect(sut.endpoints).toEqual(apiConfig.endpoints);
   });
 
+  it('should be instantiated using `gateway` if `endpoint` is not available', () => {
+    // Given
+    const apiConfig = {
+      url: 'my-api',
+      gateway: {
+        info: 'api-info',
+      },
+    };
+    const http = {
+      fetch: () => {},
+    };
+    const HTTPError = 'HTTPError';
+    let sut = null;
+    // When
+    sut = new APIClient(apiConfig, http, HTTPError);
+    // Then
+    expect(sut).toBeInstanceOf(APIClientBase);
+    expect(sut).toBeInstanceOf(APIClient);
+    expect(sut.apiConfig).toEqual(apiConfig);
+    expect(sut.url).toBe(apiConfig.url);
+    expect(sut.endpoints).toEqual(apiConfig.gateway);
+  });
+
+
   it('should format error responses using the HTTPError service', () => {
     // Given
     const apiConfig = {


### PR DESCRIPTION
### What does this PR do?

While updating a Jimpex app that implemented the gateway controller, I had to add an internal request for an endpoint that was already defined on the gateway configuration, but since I needed an API client, I had to duplicate its configuration:

```js
{
  ...
  myAPI: {
    url: ...,
    gateway: {
      myEndpoint: ...,
    },
    endpoints: {
      myEndpoint: ...,
    },
  },
  ...
}
```

Since `gateway` and `endpoints` share almost the exact same format, I thought it would be a good idea to use `gateway` as a fallback if `endpoints` is not available; that way, there's no need to duplicate configurations.

### How should it be tested manually?

Take an app with an API client already working, make sure the API configuration doesn't have a `gateway` and change `endpoints` to `gateway`... the app should keep working as it was before.

Of course, don't forget to...

```bash
yarn test
# or
npm test
```

### Are there any related PRs?

### TODOs
