### PR TITLE
feat: HSTS header

### DIFF
--- a/README-esdoc.md
+++ b/README-esdoc.md
@@ -378,6 +378,7 @@ Jimpex comes with a few services, middlewares and controllers that you can impor
 
 - **Error handler:** Allows you to generate responses for errors and potentially hide uncaught exceptions under a generic message, unless it's disabled via configuration settings.
 - **Force HTTPS:** Redirect all incoming traffic from HTTP to HTTPS. It also allows you to set routes to ignore the redirection.
+- **HSTS header:** It configures a `Strict-Transport-Security` header and includes it on every response.
 - **Fast HTML:** Allows your app to skip unnecessary processing by showing an specific HTML when a requested route doesn't have a controller for it or is not on a "whitelist".
 - **Show HTML:** A really simple middleware to serve an HTML file. Its true feature is that it can be hooked up to the **HTML Generator** service.
 - **Version validator:** If you mount it on a route it will generate a `409` error if the request doesn't have a version parameter with the same version as the one on the configuration.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Jimpex comes with a few services, middlewares and controllers that you can impor
 
 - **Error handler:** Allows you to generate responses for errors and potentially hide uncaught exceptions under a generic message, unless it's disabled via configuration settings.
 - **Force HTTPS:** Redirect all incoming traffic from HTTP to HTTPS. It also allows you to set routes to ignore the redirection.
+- **HSTS header:** It configures a `Strict-Transport-Security` header and includes it on every response.
 - **Fast HTML:** Allows your app to skip unnecessary processing by showing an specific HTML when a requested route doesn't have a controller for it or is not on a "whitelist".
 - **Show HTML:** A really simple middleware to serve an HTML file. Its true feature is that it can be hooked up to the **HTML Generator** service.
 - **Version validator:** If you mount it on a route it will generate a `409` error if the request doesn't have a version parameter with the same version as the one on the configuration.

--- a/documents/middlewares.md
+++ b/documents/middlewares.md
@@ -102,7 +102,7 @@ const {
 class App extends Jimpex {
   boot() {
     // Add the middleware first.
-    this.use(errorHandler);
+    this.use(forceHTTPS);
   }
 }
 ```
@@ -129,6 +129,57 @@ class App extends Jimpex {
 ```
 
 **VERY IMPORTANT:** The forced redirection will only happen if your configuration has a setting named `forceHTTPS` with a value of `true`.
+
+## HSTS
+
+It configures a `Strict-Transport-Security` header and includes it on every response.
+
+- Module: `common`
+
+```js
+const {
+  Jimpex,
+  middlewares: {
+    common: { hsts },
+  },
+};
+
+class App extends Jimpex {
+  boot() {
+    // Add the middleware first.
+    this.use(hsts);
+  }
+}
+```
+
+You can also use it as a function and send the following options:
+
+- `maxAge`: The time, in seconds, that the browser should remember that a site is only to be accessed using HTTPS. The default value is `31536000` (one year).
+- `includeSubDomains`: Whether or not the rule should apply to all sub domains. The default value is `true`.
+- `preload`: Whether or not to include on the major browsers' preload list. This directive is not part of the specification, for more information about it, you should check the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) for the header. The default value is `false`.
+
+```js
+const {
+  Jimpex,
+  middlewares: {
+    common: { hsts },
+  },
+};
+
+class App extends Jimpex {
+  boot() {
+    // Add the middleware first.
+    this.use(hsts({
+      maxAge: 5,
+      includeSubDomains: false,
+    }));
+  }
+}
+```
+
+> You can also send an `enabled` option, set to `false`, in case you want to disable the middleware.
+
+If you don't send options, before using the defaults, it will first try to obtain them for a `hsts` key on the `appConfiguration` service, so you can also manage how the feature works from your project configuration.
 
 ## Fast HTML
 

--- a/src/middlewares/common/hsts.js
+++ b/src/middlewares/common/hsts.js
@@ -1,0 +1,103 @@
+const { middlewareCreator } = require('../../utils/wrappers');
+
+/**
+ * @typedef {Object} HSTSMiddlewareOptions
+ * @description The options to customize the HSTS header value.
+ * @property {number}  [maxAge=31536000]        The time, in seconds, that the browser should
+ *                                              remember that a site is only to be accessed using
+ *                                              HTTPS.
+ * @property {boolean} [includeSubDomains=true] Whether or not the rule should apply to all sub
+ *                                              domains.
+ * @property {boolea}  [preload=false]          Whether or not to include on the major browsers'
+ *                                              preload list. This directive is not part of the
+ *                                              specification, for more information about it, you
+ *                                              should check the MDN documentation for the header.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+ */
+
+/**
+ * It configures a `Strict-Transport-Security` header and includes it on every response.
+ * @see https://tools.ietf.org/html/rfc6797
+ */
+class HSTSMiddleware {
+  /**
+   * @param {HSTSMiddlewareOptions} [options={}] The options to customize the header value.
+   */
+  constructor(options = {}) {
+    /**
+     * The value of the header that will be included on every response.
+     * @type {string}
+     * @access protected
+     * @ignore
+     */
+    this._header = this._buildHeader(Object.assign(
+      {
+        maxAge: 31536000,
+        includeSubDomains: true,
+        preload: false,
+      },
+      options
+    ));
+  }
+  /**
+   * Returns the Express middleware that includes the header on the response.
+   * @return {ExpressMiddleware}
+   */
+  middleware() {
+    return (req, res, next) => {
+      res.setHeader('Strict-Transport-Security', this._header);
+      next();
+    };
+  }
+  /**
+   * The value of the header that will be included on every response.
+   * @type {string}
+   */
+  get header() {
+    return this._header;
+  }
+  /**
+   * Creates the value for the header.
+   * @param {HSTSMiddlewareOptions} options The options to customize the header value.
+   * @return {string}
+   * @access protected
+   * @ignore
+   */
+  _buildHeader(options) {
+    const directives = [`max-age=${options.maxAge}`];
+    if (options.includeSubDomains) {
+      directives.push('includeSubDomains');
+    }
+
+    if (options.preload) {
+      directives.push('preload');
+    }
+
+    return directives.join('; ');
+  }
+}
+/**
+ * A middleware that creates and includes a `Strict-Transport-Security` header on every response.
+ * If the `options` parameter doesn't include the value for `maxAge`, the middleware will ask
+ * the {@link AppConfiguration} service for the `hsts` settings as a fallback. You can take
+ * advantage of that fallback to use the middleware and manage its settings from your project
+ * configuration.
+ * Both the `options` parameter and the `hsts` can include a `enabled` (boolean) flag to either
+ * disable or enable the middleware.
+ * @type {MiddlewareCreator}
+ * @param {HSTSMiddlewareOptions} [options={}] The options to customize the header value.
+ */
+const hstsMiddleware = middlewareCreator((options = {}) => (app) => {
+  const useOptions = typeof options.maxAge !== 'undefined' ?
+    options :
+    (app.get('appConfiguration').get('hsts') || {});
+
+  return typeof useOptions.enabled === 'undefined' || useOptions.enabled ?
+    (new HSTSMiddleware(useOptions)).middleware() :
+    null;
+});
+
+module.exports = {
+  HSTSMiddleware,
+  hstsMiddleware,
+};

--- a/src/middlewares/common/index.js
+++ b/src/middlewares/common/index.js
@@ -1,7 +1,9 @@
 const { errorHandler } = require('./errorHandler');
 const { forceHTTPS } = require('./forceHTTPS');
+const { hsts } = require('./hsts');
 
 module.exports = {
   errorHandler,
   forceHTTPS,
+  hsts,
 };

--- a/tests/middlewares/common/hsts.test.js
+++ b/tests/middlewares/common/hsts.test.js
@@ -1,0 +1,158 @@
+jest.unmock('/src/utils/wrappers');
+jest.unmock('/src/middlewares/common/hsts');
+
+require('jasmine-expect');
+const {
+  HSTSMiddleware,
+  hstsMiddleware,
+} = require('/src/middlewares/common/hsts');
+
+describe('middlewares/common:hstsMiddleware', () => {
+  it('should be instantiated with its default options', () => {
+    // Given
+    let sut = null;
+    // When
+    sut = new HSTSMiddleware();
+    // Then
+    expect(sut).toBeInstanceOf(HSTSMiddleware);
+    expect(sut.header).toBe('max-age=31536000; includeSubDomains');
+  });
+
+  it('should be instantiated with custom options', () => {
+    // Given
+    let sut = null;
+    const maxAge = 2506;
+    const includeSubDomains = false;
+    const preload = true;
+    // When
+    sut = new HSTSMiddleware({
+      maxAge,
+      includeSubDomains,
+      preload,
+    });
+    // Then
+    expect(sut.header).toBe(`max-age=${maxAge}; preload`);
+  });
+
+  it('should return a middleware that sets the HSTS header', () => {
+    // Given
+    let sut = null;
+    let middleware = null;
+    const maxAge = 2506;
+    const includeSubDomains = false;
+    const preload = true;
+    const request = null;
+    const setHeader = jest.fn();
+    const response = { setHeader };
+    const next = jest.fn();
+    // When
+    sut = new HSTSMiddleware({
+      maxAge,
+      includeSubDomains,
+      preload,
+    });
+    middleware = sut.middleware();
+    middleware(request, response, next);
+    // Then
+    expect(setHeader).toHaveBeenCalledTimes(1);
+    expect(setHeader).toHaveBeenCalledWith(
+      'Strict-Transport-Security',
+      `max-age=${maxAge}; preload`
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create a middleware with the options from the configuration', () => {
+    // Given
+    const appConfiguration = {
+      get: jest.fn(() => ({})),
+    };
+    const app = {
+      get: jest.fn(() => appConfiguration),
+    };
+    let middleware = null;
+    let toCompare = null;
+    // When
+    toCompare = new HSTSMiddleware();
+    middleware = hstsMiddleware.connect(app);
+    // Then
+    expect(middleware.toString()).toEqual(toCompare.middleware().toString());
+    expect(app.get).toHaveBeenCalledTimes(1);
+    expect(app.get).toHaveBeenCalledWith('appConfiguration');
+    expect(appConfiguration.get).toHaveBeenCalledTimes(1);
+    expect(appConfiguration.get).toHaveBeenCalledWith('hsts');
+  });
+
+  it('should create a middleware even if the configuration doesn\'t have hsts settings', () => {
+    // Given
+    const appConfiguration = {
+      get: jest.fn(),
+    };
+    const app = {
+      get: jest.fn(() => appConfiguration),
+    };
+    let middleware = null;
+    let toCompare = null;
+    const request = null;
+    const setHeader = jest.fn();
+    const response = { setHeader };
+    const next = jest.fn();
+    // When
+    toCompare = new HSTSMiddleware();
+    middleware = hstsMiddleware.connect(app);
+    middleware(request, response, next);
+    // Then
+    expect(middleware.toString()).toEqual(toCompare.middleware().toString());
+    expect(app.get).toHaveBeenCalledTimes(1);
+    expect(app.get).toHaveBeenCalledWith('appConfiguration');
+    expect(appConfiguration.get).toHaveBeenCalledTimes(1);
+    expect(appConfiguration.get).toHaveBeenCalledWith('hsts');
+    expect(setHeader).toHaveBeenCalledTimes(1);
+    expect(setHeader).toHaveBeenCalledWith(
+      'Strict-Transport-Security',
+      'max-age=31536000; includeSubDomains'
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('shouldn\'t return the middleware if the \'enabled\' flag is \'false\'', () => {
+    // Given
+    const appConfiguration = {
+      get: jest.fn(() => ({
+        enabled: false,
+      })),
+    };
+    const app = {
+      get: jest.fn(() => appConfiguration),
+    };
+    let middleware = null;
+    // When
+    middleware = hstsMiddleware.connect(app);
+    // Then
+    expect(middleware).toBeNull();
+  });
+
+  it('should create a middleware with custom options', () => {
+    // Given
+    const app = {
+      get: jest.fn(),
+    };
+    let middleware = null;
+    const maxAge = 2506;
+    const includeSubDomains = false;
+    const request = null;
+    const setHeader = jest.fn();
+    const response = { setHeader };
+    const next = jest.fn();
+    // When
+    middleware = hstsMiddleware({ maxAge, includeSubDomains }).connect(app);
+    middleware(request, response, next);
+    // Then
+    expect(setHeader).toHaveBeenCalledTimes(1);
+    expect(setHeader).toHaveBeenCalledWith(
+      'Strict-Transport-Security',
+      `max-age=${maxAge}`
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

It adds a new built-in middleware to configure and include an [HSTS header]() on every server response.

For more information about the middleware, please read the documentation on this same PR.

### How should it be tested manually?

Try the different configuration methods explained on the documentation and...

```bash
yarn test
# or
npm test
```