### PR TITLE
v5.1.1: fix: use the right export name for the HSTS middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "jimpex",
     "description": "Express as dependency injection container.",
     "homepage": "https://homer0.github.io/jimpex/",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "repository": "homer0/jimpex",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/src/middlewares/common/hsts.js
+++ b/src/middlewares/common/hsts.js
@@ -1,7 +1,7 @@
 const { middlewareCreator } = require('../../utils/wrappers');
 
 /**
- * @typedef {Object} HSTSMiddlewareOptions
+ * @typedef {Object} HSTSOptions
  * @description The options to customize the HSTS header value.
  * @property {number}  [maxAge=31536000]        The time, in seconds, that the browser should
  *                                              remember that a site is only to be accessed using
@@ -19,9 +19,9 @@ const { middlewareCreator } = require('../../utils/wrappers');
  * It configures a `Strict-Transport-Security` header and includes it on every response.
  * @see https://tools.ietf.org/html/rfc6797
  */
-class HSTSMiddleware {
+class HSTS {
   /**
-   * @param {HSTSMiddlewareOptions} [options={}] The options to customize the header value.
+   * @param {HSTSOptions} [options={}] The options to customize the header value.
    */
   constructor(options = {}) {
     /**
@@ -58,7 +58,7 @@ class HSTSMiddleware {
   }
   /**
    * Creates the value for the header.
-   * @param {HSTSMiddlewareOptions} options The options to customize the header value.
+   * @param {HSTSOptions} options The options to customize the header value.
    * @return {string}
    * @access protected
    * @ignore
@@ -85,19 +85,19 @@ class HSTSMiddleware {
  * Both the `options` parameter and the `hsts` can include a `enabled` (boolean) flag to either
  * disable or enable the middleware.
  * @type {MiddlewareCreator}
- * @param {HSTSMiddlewareOptions} [options={}] The options to customize the header value.
+ * @param {HSTSOptions} [options={}] The options to customize the header value.
  */
-const hstsMiddleware = middlewareCreator((options = {}) => (app) => {
+const hsts = middlewareCreator((options = {}) => (app) => {
   const useOptions = typeof options.maxAge !== 'undefined' ?
     options :
     (app.get('appConfiguration').get('hsts') || {});
 
   return typeof useOptions.enabled === 'undefined' || useOptions.enabled ?
-    (new HSTSMiddleware(useOptions)).middleware() :
+    (new HSTS(useOptions)).middleware() :
     null;
 });
 
 module.exports = {
-  HSTSMiddleware,
-  hstsMiddleware,
+  HSTS,
+  hsts,
 };

--- a/tests/middlewares/common/hsts.test.js
+++ b/tests/middlewares/common/hsts.test.js
@@ -3,18 +3,18 @@ jest.unmock('/src/middlewares/common/hsts');
 
 require('jasmine-expect');
 const {
-  HSTSMiddleware,
-  hstsMiddleware,
+  HSTS,
+  hsts,
 } = require('/src/middlewares/common/hsts');
 
-describe('middlewares/common:hstsMiddleware', () => {
+describe('middlewares/common:hsts', () => {
   it('should be instantiated with its default options', () => {
     // Given
     let sut = null;
     // When
-    sut = new HSTSMiddleware();
+    sut = new HSTS();
     // Then
-    expect(sut).toBeInstanceOf(HSTSMiddleware);
+    expect(sut).toBeInstanceOf(HSTS);
     expect(sut.header).toBe('max-age=31536000; includeSubDomains');
   });
 
@@ -25,7 +25,7 @@ describe('middlewares/common:hstsMiddleware', () => {
     const includeSubDomains = false;
     const preload = true;
     // When
-    sut = new HSTSMiddleware({
+    sut = new HSTS({
       maxAge,
       includeSubDomains,
       preload,
@@ -46,7 +46,7 @@ describe('middlewares/common:hstsMiddleware', () => {
     const response = { setHeader };
     const next = jest.fn();
     // When
-    sut = new HSTSMiddleware({
+    sut = new HSTS({
       maxAge,
       includeSubDomains,
       preload,
@@ -73,8 +73,8 @@ describe('middlewares/common:hstsMiddleware', () => {
     let middleware = null;
     let toCompare = null;
     // When
-    toCompare = new HSTSMiddleware();
-    middleware = hstsMiddleware.connect(app);
+    toCompare = new HSTS();
+    middleware = hsts.connect(app);
     // Then
     expect(middleware.toString()).toEqual(toCompare.middleware().toString());
     expect(app.get).toHaveBeenCalledTimes(1);
@@ -98,8 +98,8 @@ describe('middlewares/common:hstsMiddleware', () => {
     const response = { setHeader };
     const next = jest.fn();
     // When
-    toCompare = new HSTSMiddleware();
-    middleware = hstsMiddleware.connect(app);
+    toCompare = new HSTS();
+    middleware = hsts.connect(app);
     middleware(request, response, next);
     // Then
     expect(middleware.toString()).toEqual(toCompare.middleware().toString());
@@ -127,7 +127,7 @@ describe('middlewares/common:hstsMiddleware', () => {
     };
     let middleware = null;
     // When
-    middleware = hstsMiddleware.connect(app);
+    middleware = hsts.connect(app);
     // Then
     expect(middleware).toBeNull();
   });
@@ -145,7 +145,7 @@ describe('middlewares/common:hstsMiddleware', () => {
     const response = { setHeader };
     const next = jest.fn();
     // When
-    middleware = hstsMiddleware({ maxAge, includeSubDomains }).connect(app);
+    middleware = hsts({ maxAge, includeSubDomains }).connect(app);
     middleware(request, response, next);
     // Then
     expect(setHeader).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### What does this PR do?

I forgot to push the commit that renamed the HSTS middleware before doing the release, this PR fixes that:

- `HSTSMiddleware` -> `HSTS`
- `hstsMiddleware` -> `hsts`

### How should it be tested manually?

Try to import `middlewares: { hsts }` from `jimpex`, it shouldn't be `undefined`; also...

```bash
yarn test
# or
npm test
```
