### PR TITLE
02 - Use the new Jimple wrappers from wootils

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "wootils": "^4.0.0",
+      "wootils": "^4.0.1",
       "jimple": "^1.5.0",
       "express": "^4.17.1",
       "body-parser": "^1.19.0",
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
       "eslint": "^7.6.0",
-      "eslint-plugin-homer0": "^5.0.1",
+      "eslint-plugin-homer0": "^5.0.2",
       "jest-ex": "^9.0.0",
       "jest-cli": "^26.2.2",
       "jasmine-expect": "^4.0.3",

--- a/src/services/frontend/index.js
+++ b/src/services/frontend/index.js
@@ -1,5 +1,6 @@
+const { providers } = require('../../utils/wrappers');
 const { frontendFs } = require('./frontendFs');
 
-module.exports = {
+module.exports = providers({
   frontendFs,
-};
+});

--- a/src/services/html/index.js
+++ b/src/services/html/index.js
@@ -1,5 +1,6 @@
+const { providers } = require('../../utils/wrappers');
 const { htmlGenerator } = require('./htmlGenerator');
 
-module.exports = {
+module.exports = providers({
   htmlGenerator,
-};
+});

--- a/src/utils/wrappers.js
+++ b/src/utils/wrappers.js
@@ -1,256 +1,173 @@
+const {
+  provider,
+  providerCreator,
+  providers,
+  resource,
+  resourceCreator,
+} = require('wootils/shared/jimpleFns');
+
 /**
- * @typedef {Object} Provider
- * @description An object that when registered on Jimpex will take care of setting up services
- *              and/or configuring the app. The method Jimpex uses to register a provider is
- *              {@link Jimpex#register} and is inherit from {@link Jimple}.
- * @property {ProviderRegistrationCallback} register The function Jimpex calls when registering
- *                                                   the provider.
- * @property {boolean}                      provider A flag set to `true` to identify the resource
- *                                                   as a service provider.
+ * @typedef {import('../app')} Jimpex
  */
 
 /**
- * @callback ProviderCreator
- * @description A special kind of {@link Provider} because it can be used with
- *              {@link Jimpex#register} as a regular provider, or it can be called as a function
- *              with custom paramters in order to obtain a "configured {@link Provider}".
- * @returns {Provider}
+ * @typedef {import('express').Router} Router
+ * @typedef {import('express').RequestHandler} RequestHandler
+ * @typedef {import('express').ErrorRequestHandler} ErrorRequestHandler
+ * @typedef {RequestHandler|ErrorRequestHandler} ExpressMiddleware
+ * @typedef {import('wootils/esm/shared/jimpleFns').Provider} Provider
+ * @typedef {import('wootils/esm/shared/jimpleFns').Providers} Providers
  */
 
 /**
- * @callback ProviderRegistrationCallback
- * @description The function called by the app container in order to register a service provider.
- * @param {Jimpex} app The instance of the app container.
+ * @template O
+ * @typedef {import('wootils/esm/shared/jimpleFns').ProviderCreator<O>} ProviderCreator<O>
  */
 
 /**
- * @callback ProviderCreatorCallback
- * @description A function called in order to generate a {@link Provider}. They usually have
- *              different options that will be sent to the service registration.
- * @returns {ProviderRegistrationCallback}
- */
-
-/**
+ * An object that when mounted on Jimpex will take care of handling a list of specific routes. The
+ * method Jimpex uses to mount a controller is {@link Jimpex#mount}.
+ *
  * @typedef {Object} Controller
- * @description An object that when mounted on Jimpex will take care of handling a list of specific
- *              routes. The method Jimpex uses to mount a controller is {@link Jimpex#mount}.
- * @property {ControllerMountCallback} connect    The function Jimpex calls when mounting the
- *                                                controller.
- * @property {boolean}                 controller A flag set to `true` to identify the resource
- *                                                as a routes controller.
+ * @property {ControllerConnectFn} connect    The function Jimpex calls when mounting the
+ *                                            controller.
+ * @property {boolean}             controller A flag set to `true` to identify the resource
+ *                                            as a routes controller.
  */
 
 /**
- * @callback ControllerCreator
- * @description A special kind of {@link Controller} because it can be used with
- *              {@link Jimpex#mount} as a regular controller, or it can be called as a function
- *              with custom paramters in order to obtain a "configured {@link Controller}".
- * @returns {Controller}
- */
-
-/**
- * @callback ControllerMountCallback
- * @description The function called by the app container in order to mount a routes controller.
- * @param {Jimpex} app   The instance of the app container.
+ * The function called by the application container in order to mount a routes controller.
+ *
+ * @callback ControllerConnectFn
+ * @param {Jimpex} app   The instance of the application container.
  * @param {string} route The route where the controller will be mounted.
- * @returns {Array|ExpressRouter} The list of routes the controller will manage, or a router
- *                               instance.
+ * @returns {Router} The controller router.
  */
 
 /**
- * @callback ControllerCreatorCallback
- * @description A function called in order to generate a {@link Controller}. They usually have
- *              different options that will be sent to the controller creation.
- * @returns {ControllerMountCallback}
+ * A function called in order to generate a {@link Controller}. They usually have different options
+ * that will be sent to the controller creation.
+ *
+ * @callback ControllerCreatorFn
+ * @returns {ControllerConnectFn}
  */
 
 /**
+ * A special kind of {@link Controller} that can be used with {@link Jimpex#mount} as a regular
+ * controller, or it can be called as a function with custom parameters in order to obtain
+ * a "configured {@link Controller}".
+ *
+ * @callback ControllerCreator
+ * @param {Partial<O>} [options={}] The options to create the controller.
+ * @returns {Controller}
+ * @template O
+ */
+
+/**
+ * An object that when mounted on Jimpex add an {@link ExpressMiddleware} to the app. The method
+ * Jimpex uses to mount a middleware is {@link Jimpex#use}.
+ *
  * @typedef {Object} Middleware
- * @description An object that when mounted on Jimpex add an {@link ExpressMiddleware} to the app.
- *              The method Jimpex uses to mount a middleware is {@link Jimpex#use}.
- * @property {MiddlewareUseCallback} connect    The function Jimpex calls when mounting the
- *                                              middleware.
- * @property {boolean}               middleware A flag set to `true` to identify the resource
- *                                              as a middleware.
+ * @property {MiddlewareConnectFn} connect    The function Jimpex calls when mounting the
+ *                                            middleware.
+ * @property {boolean}             middleware A flag set to `true` to identify the resource as a
+ *                                            middleware.
  */
 
 /**
+ * The function called by the application container in order to use a middleware.
+ *
+ * @callback MiddlewareConnectFn
+ * @param {Jimpex} app The instance of the application container.
+ * @returns {?ExpressMiddleware} A middleware for Express to use. It can also return `null` in
+ *                               case there's a reason for the middleware not to be active.
+ */
+
+/**
+ * A function called in order to generate a {@link Middleware}. They usually have different options
+ * that will be sent to the middleware creation.
+ *
+ * @callback MiddlewareCreatorFn
+ * @returns {MiddlewareConnectFn}
+ */
+
+/**
+ * A special kind of {@link Middleware} that can be used with {@link Jimpex#use} as a regular
+ * middleware, or it can be called as a function with custom parameters in order to obtain
+ * a "configured {@link Middleware}".
+ *
  * @callback MiddlewareCreator
- * @description A special kind of {@link Middleware} because it can be used with
- *              {@link Jimpex#use} as a regular middleware, or it can be called as a function
- *              with custom paramters in order to obtain a "configured {@link Middleware}".
+ * @param {Partial<O>} [options={}] The options to create the controller.
  * @returns {Middleware}
+ * @template O
  */
 
 /**
- * @callback MiddlewareUseCallback
- * @description The function called by the app container in order to use a middleware.
- * @param {Jimpex} app The instance of the app container.
- * @returns {?ExpressMiddleware} A middleware for Express to use. It can also return `null` in case
- *                              there's a reason for the middleware not to be active.
- */
-
-/**
- * @callback MiddlewareCreatorCallback
- * @description A function called in order to generate a {@link Middleware}. They usually have
- *              different options that will be sent to the middleware creation.
- * @returns {MiddlewareUseCallback}
- */
-
-/**
- * This is a helper the wrappers use in order to create an object by placing a given function
- * on an specific key.
- *
- * @param {string}   name The name of the resource. It will also be added to the object as a
- *                        property with the value of `true`.
- * @param {string}   key  The key in which the function will be placed.
- * @param {Function} fn   The function to insert in the object.
- * @returns {Object}
- * @ignore
- */
-const resource = (name, key, fn) => ({
-  [key]: fn,
-  [name]: true,
-});
-/**
- * Similar to `resource`, this helper creates an "object" and places a given function on an
- * specify key. The difference is that instead of being an actual object what gets created, it's
- * another function, then a proxy is added to that function in order to intercept the `key`
- * property and return the result of the function.
- *
- * This is kind of hard to explain, so let's compare it with `resource` and use a proper example.
- * - `resource`: (name, key, fn) => ({ [key]: fn, [name]: true }).
- * - `resourceCreator`: ((name, key, creatorFn) => creatorFn(...) => fn)[key]: creatorFn().
- *
- * While `resource` is meant to create objects with a resource function, this is meant to create
- * those resource functions by sending them "optional paramters", and they are optionals because
- * if you access the `key` property, it would be the same as calling the `creatorFn` without
- * paramters.
- *
- * @param {string}   name      The name of the resource, to be added as a property of both the
- *                             generated resource and the one with the proxy. The value of the
- *                             property will be `true`.
- * @param {string}   key       The key in which the creator function will be placed in case it's
- *                             used without parameters; and also the key in which the result
- *                             function from the creator will be placed if called with parameters.
- * @param {Function} creatorFn The function that generates the "resource function".
- * @returns {Function}
- * @ignore
- */
-const resourceCreator = (name, key, creatorFn) => new Proxy(
-  (...args) => resource(name, key, creatorFn(...args)),
-  {
-    name,
-    resource: null,
-    get(target, property) {
-      let result;
-      if (property === this.name) {
-        result = true;
-      } else if (property === key) {
-        if (this.resource === null) {
-          this.resource = creatorFn();
-        }
-        result = this.resource;
-      } else {
-        result = target[property];
-      }
-
-      return result;
-    },
-  },
-);
-/**
- * Generates a service provider for the app container.
- *
- * @param {ProviderRegistrationCallback} registerFn A function that will be called the moment the
- *                                                  app registers the provider.
- * @returns {Provider}
- */
-const provider = (registerFn) => resource('provider', 'register', registerFn);
-/**
- * Generates a collection of service providers that can be registered all at once or one by one.
- * You can send the collection directly to the `.register()` and it will register all its
- * "children"; and if you want to register one provider at a time, you can access them by name,
- * as the collection is a regular object.
+ * Generates a routes controller for the application container to mount.
  *
  * @example
- * const collection = providers({ one: providerOne, two: providerTwo });
- * // Register all at once
- * app.register(collection);
- * // Register one by one
- * app.register(collection.one);
- * app.register(collection.two);
- *
- * @param {Object} items A dictionary of service providers; the keys will be for the collection
- *                       object, and the values the one that will get send to `.register()`.
- * @returns {Provider}
- * @throws {Error} If one of the items has the key `register` or `providers`.
- */
-const providers = (items) => {
-  const invalidNames = Object.keys(items).some((name) => (
-    ['register', 'providers'].includes(name)
-  ));
-  if (invalidNames) {
-    throw new Error(
-      'You can\'t create a collection with a providers called `register` or `providers`',
-    );
-  }
-
-  return Object.assign(
-    resource(
-      'providers',
-      'register',
-      (app) => Object.keys(items).forEach((item) => {
-        app.register(items[item]);
-      }),
-    ),
-    items,
-  );
-};
-/**
- * Generates a configurable service provider for the app container. It's configurable because
- * the creator, instead of just being sent to the container to register, it can also be called
- * as a function with custom parameters the service can receive.
- *
- * @example
- * const myService = providerCreator((options) => (app) => {
- *   app.set('myService', () => new MyService(options));
+ * const myController = controller((app) => {
+ *   const router = app.get('router');
+ *   const ctrl = new MyController();
+ *   return router
+ *   .get('...', ctrl.doSomething())
+ *   .post('...', ctrl.doSomethingElse());
  * });
  *
- * @param {ProviderCreatorCallback} creatorFn The function that generates the provider.
- * @returns {ProviderCreator}
- */
-const providerCreator = (creatorFn) => resourceCreator('provider', 'register', creatorFn);
-/**
- * Generates a routes controller for the app container to mount.
- *
- * @param {ControllerMountCallback} connectFn A function that will be called the moment the app
- *                                            mounts the controller. It should return a list of
- *                                            routes.
+ * @param {ControllerConnectFn} connectFn A function that will be called the moment the app mounts
+ *                                        the controller.
  * @returns {Controller}
  */
 const controller = (connectFn) => resource('controller', 'connect', connectFn);
 /**
- * Generates a configurable routes controller for the app to mount. It's configurable because
- * the creator, instead of just being sent to the container to mount, it can also be called
+ * Generates a configurable routes controller for the application to mount. It's configurable
+ * because the creator, instead of just being sent to the container to mount, it can also be called
  * as a function with custom parameters the controller can receive.
  *
  * @example
- * const myController = controllerCreator((options) => (app) => {
+ * const myController = controllerCreator((options = {}) => (app) => {
  *   const router = app.get('router');
  *   const ctrl = new MyController(options);
- *   return [router.get('...', ctrl.doSomething())];
+ *   return router
+ *   .get('...', ctrl.doSomething())
+ *   .post('...', ctrl.doSomethingElse());
  * });
  *
- * @param {ProviderCreatorCallback} creatorFn The function that generates the controller.
- * @returns {ProviderCreator}
+ * @param {ControllerCreatorFn} creatorFn The function that generates the controller.
+ * @returns {ControllerCreator<*>}
  */
 const controllerCreator = (creatorFn) => resourceCreator('controller', 'connect', creatorFn);
 /**
  * Generates a middleware for the app to use.
  *
- * @param {MiddlewareUseCallback} connectFn A function that will be called the moment the app
- *                                          mounts the middleware.
+ * @example
+ * const myMiddleware = middleware((app) => (req, res, next) => {
+ *   if (req.query.greet !== 'true') {
+ *     return next();
+ *   }
+ *
+ *   app.get('responsesBuilder').json(res, {
+ *     hello: 'world',
+ *   });
+ * });
+ *
+ * @example
+ * <caption>Disable the middleware base on a configuration option</caption>
+ * const myMiddleware = middleware((app) => {
+ *   if (app.get('appConfiguration').get('someOption') !== true) {
+ *     return null;
+ *   }
+ *
+ *   return (req, res, next) => {
+ *     if (req.query.hello !== 'world') return next();
+ *     app.get('responsesBuilder').json(res, {
+ *       hello: 'world',
+ *     });
+ *   };
+ * });
+ *
+ * @param {MiddlewareConnectFn} connectFn A function that will be called the moment the app
+ *                                        mounts the middleware.
  * @returns {Middleware}
  */
 const middleware = (connectFn) => resource('middleware', 'connect', connectFn);
@@ -260,23 +177,21 @@ const middleware = (connectFn) => resource('middleware', 'connect', connectFn);
  * custom parameters the middleware can receive.
  *
  * @example
- * const myMiddleware = middlewareCreator((options) => (app) => (
+ * const myMiddleware = middlewareCreator((options = {}) => (app) => (
  *   options.enabled ?
  *     (req, res, next) => {} :
  *     null
  * ));
  *
- * @param {ProviderCreatorCallback} creatorFn The function that generates the middleware.
- * @returns {ProviderCreator}
+ * @param {MiddlewareCreatorFn} creatorFn The function that generates the middleware.
+ * @returns {MiddlewareCreator<*>}
  */
 const middlewareCreator = (creatorFn) => resourceCreator('middleware', 'connect', creatorFn);
 
-module.exports = {
-  provider,
-  providerCreator,
-  providers,
-  controller,
-  controllerCreator,
-  middleware,
-  middlewareCreator,
-};
+module.exports.provider = provider;
+module.exports.providerCreator = providerCreator;
+module.exports.providers = providers;
+module.exports.controller = controller;
+module.exports.controllerCreator = controllerCreator;
+module.exports.middleware = middleware;
+module.exports.middlewareCreator = middlewareCreator;

--- a/tests/services/common/index.test.js
+++ b/tests/services/common/index.test.js
@@ -1,31 +1,21 @@
-jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/common');
+jest.mock('/src/utils/wrappers', () => ({
+  provider: jest.fn(() => 'provider'),
+  providers: jest.fn(() => 'providers'),
+}));
 
-require('jasmine-expect');
-const commonServices = require('/src/services/common');
+const common = require('/src/services/common');
+const { providers } = require('/src/utils/wrappers');
 
 describe('services:common', () => {
-  it('should export a method to register all the API services', () => {
-    // Given
-    const app = {
-      register: jest.fn(),
-    };
-    const expectedServices = [
-      'appError',
-      'httpError',
-      'sendFile',
-    ];
-    // When
-    commonServices.register(app);
-    // When/Then
-    expect(app.register).toHaveBeenCalledTimes(expectedServices.length);
-    expectedServices.forEach((service, index) => {
-      const registeredService = app.register.mock.calls[index][0];
-      expect(registeredService).toEqual({
-        register: expect.any(Function),
-        provider: true,
-      });
-      expect(registeredService.toString()).toBe(commonServices[service].toString());
+  it('should export a providers collection with all the common services', () => {
+    // Given/When/Then
+    expect(common).toBe('providers');
+    expect(providers).toHaveBeenCalledTimes(1);
+    expect(providers).toHaveBeenCalledWith({
+      appError: 'provider',
+      httpError: 'provider',
+      sendFile: 'provider',
     });
   });
 });

--- a/tests/services/http/index.test.js
+++ b/tests/services/http/index.test.js
@@ -1,35 +1,22 @@
-jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/http');
+jest.mock('/src/utils/wrappers', () => ({
+  provider: jest.fn(() => 'provider'),
+  providerCreator: jest.fn(() => 'providerCreator'),
+  providers: jest.fn(() => 'providers'),
+}));
 
-require('jasmine-expect');
-const httpServices = require('/src/services/http');
+const http = require('/src/services/http');
+const { providers } = require('/src/utils/wrappers');
 
 describe('services:http', () => {
-  it('should export a method to register all the HTTP services', () => {
-    // Given
-    const app = {
-      register: jest.fn(),
-    };
-    const expectedServices = {
-      apiClient: expect.any(Function),
-      http: {
-        register: expect.any(Function),
-        provider: true,
-      },
-      responsesBuilder: {
-        register: expect.any(Function),
-        provider: true,
-      },
-    };
-    const expectedServicesNames = Object.keys(expectedServices);
-    // When
-    httpServices.register(app);
-    // When/Then
-    expect(app.register).toHaveBeenCalledTimes(expectedServicesNames.length);
-    expectedServicesNames.forEach((service, index) => {
-      const [registeredService] = app.register.mock.calls[index];
-      expect(registeredService).toEqual(expectedServices[service]);
-      expect(registeredService.toString()).toBe(httpServices[service].toString());
+  it('should export a providers collection with all the HTTP services', () => {
+    // Given/When/Then
+    expect(http).toBe('providers');
+    expect(providers).toHaveBeenCalledTimes(1);
+    expect(providers).toHaveBeenCalledWith({
+      apiClient: 'providerCreator',
+      http: 'provider',
+      responsesBuilder: 'provider',
     });
   });
 });

--- a/tests/services/index.test.js
+++ b/tests/services/index.test.js
@@ -1,23 +1,21 @@
-jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services');
+jest.mock('/src/utils/wrappers', () => ({
+  provider: jest.fn(() => 'provider'),
+  providerCreator: jest.fn(() => 'providerCreator'),
+  providers: jest.fn(() => 'providers'),
+}));
 
-require('jasmine-expect');
 const services = require('/src/services');
 
 describe('services', () => {
   it('should export all the app sevices', () => {
-    // Given
-    const knownServices = [
-      'common',
-      'frontend',
-      'html',
-      'http',
-      'utils',
-    ];
-    // When/Then
-    expect(Object.keys(services).length).toBe(knownServices.length);
-    knownServices.forEach((name) => {
-      expect(services[name]).toBeObject();
+    // Given/When/Then
+    expect(services).toEqual({
+      common: 'providers',
+      frontend: 'providers',
+      html: 'providers',
+      http: 'providers',
+      utils: 'providers',
     });
   });
 });

--- a/tests/services/utils/index.test.js
+++ b/tests/services/utils/index.test.js
@@ -1,27 +1,19 @@
-jest.unmock('/src/utils/wrappers');
 jest.unmock('/src/services/utils');
+jest.mock('/src/utils/wrappers', () => ({
+  providerCreator: jest.fn(() => 'providerCreator'),
+  providers: jest.fn(() => 'providers'),
+}));
 
-require('jasmine-expect');
-const utilsServices = require('/src/services/utils');
+const utils = require('/src/services/utils');
+const { providers } = require('/src/utils/wrappers');
 
 describe('services:utils', () => {
-  it('should export a method to register all the API services', () => {
-    // Given
-    const app = {
-      register: jest.fn(),
-    };
-    const expectedServices = {
-      ensureBearerToken: expect.any(Function),
-    };
-    const expectedServicesNames = Object.keys(expectedServices);
-    // When
-    utilsServices.register(app);
-    // When/Then
-    expect(app.register).toHaveBeenCalledTimes(expectedServicesNames.length);
-    expectedServicesNames.forEach((service, index) => {
-      const [registeredService] = app.register.mock.calls[index];
-      expect(registeredService).toEqual(expectedServices[service]);
-      expect(registeredService.toString()).toBe(utilsServices[service].toString());
+  it('should export a providers collection with all the utility services', () => {
+    // Given/When/Then
+    expect(utils).toBe('providers');
+    expect(providers).toHaveBeenCalledTimes(1);
+    expect(providers).toHaveBeenCalledWith({
+      ensureBearerToken: 'providerCreator',
     });
   });
 });

--- a/tests/utils/wrappers.test.js
+++ b/tests/utils/wrappers.test.js
@@ -1,216 +1,79 @@
 jest.unmock('/src/utils/wrappers');
+jest.mock('wootils/shared/jimpleFns');
 
 require('jasmine-expect');
 const {
-  provider,
-  providerCreator,
-  providers,
   controller,
   controllerCreator,
   middleware,
   middlewareCreator,
 } = require('/src/utils/wrappers');
+const { resource, resourceCreator } = require('wootils/shared/jimpleFns');
 
 describe('utils/wrappers', () => {
-  describe('provider', () => {
-    it('should create a service provider with a `register` function', () => {
-      // Given
-      const serviceProvider = 'serviceProvider';
-      let result = null;
-      // When
-      result = provider(serviceProvider);
-      // Then
-      expect(result).toEqual({
-        register: serviceProvider,
-        provider: true,
-      });
-    });
-
-    it('should create a service provider creator', () => {
-      // Given
-      const serviceProvider = 'serviceProvider';
-      const creatorFn = jest.fn(() => serviceProvider);
-      const options = 'options';
-      let creator = null;
-      let result = null;
-      // When
-      creator = providerCreator(creatorFn);
-      result = creator(options);
-      // Then
-      expect(result).toEqual({
-        register: serviceProvider,
-        provider: true,
-      });
-      expect(creatorFn).toHaveBeenCalledTimes(1);
-      expect(creatorFn).toHaveBeenCalledWith(options);
-    });
-
-    it('should create a service provider creator that can be used without options', () => {
-      // Given
-      const serviceProvider = 'serviceProvider';
-      const creatorFn = jest.fn(() => serviceProvider);
-      let creator = null;
-      // When
-      creator = providerCreator(creatorFn);
-      // Then
-      expect(creator.register).toBe(serviceProvider);
-      expect(creator.provider).toBeTrue();
-      expect(creator.anyOtherProp).toBeUndefined(); // to validate the getter.
-      expect(creatorFn).toHaveBeenCalledTimes(1);
-      expect(creatorFn).toHaveBeenCalledWith();
-    });
-
-    it('should create a service provider with default options just once', () => {
-      // Given
-      const serviceProvider = 'serviceProvider';
-      const creatorFn = jest.fn(() => serviceProvider);
-      let creator = null;
-      // When
-      creator = providerCreator(creatorFn);
-      // Then
-      expect(creator.register).toBe(serviceProvider);
-      expect(creator.register).toBe(serviceProvider); // this is the second trigger for the proxy.
-      expect(creatorFn).toHaveBeenCalledTimes(1);
-      expect(creatorFn).toHaveBeenCalledWith();
-    });
-
-    it('should create a providers collection', () => {
-      // Given
-      const serviceProviderOne = 'serviceProviderOne';
-      const serviceProviderTwo = 'serviceProviderTwo';
-      let collection = null;
-      // When
-      collection = providers({
-        one: serviceProviderOne,
-        two: serviceProviderTwo,
-      });
-      // Then
-      expect(collection.one).toBe(serviceProviderOne);
-      expect(collection.two).toBe(serviceProviderTwo);
-      expect(collection.three).toBeUndefined(); // to validate the getter.
-    });
-
-    it('should create a collection to register multiple providers at once', () => {
-      // Given
-      const app = {
-        register: jest.fn(),
-      };
-      const services = {
-        one: 'serviceProviderOne',
-        two: 'serviceProviderTwo',
-      };
-      const servicesNames = Object.keys(services);
-      let collection = null;
-      // When
-      collection = providers(services);
-      collection.register(app);
-      // Then
-      expect(app.register).toHaveBeenCalledTimes(servicesNames.length);
-      servicesNames.forEach((name) => {
-        expect(app.register).toHaveBeenCalledWith(services[name]);
-      });
-    });
-
-    it('should throw an error when trying to create a collection with invalid providers', () => {
-      // Given/When/Then
-      expect(() => providers({ providers: 'something' }))
-      .toThrow(/You can't create a collection with a providers called `register` or `providers`/i);
-    });
-  });
-
   describe('controller', () => {
-    it('should create a route controller with a `connect` function', () => {
+    beforeEach(() => {
+      resource.mockReset();
+      resourceCreator.mockReset();
+    });
+
+    it('should create a route controller', () => {
       // Given
       const routeController = 'routeController';
+      resource.mockImplementationOnce((_, __, fn) => fn);
       let result = null;
       // When
       result = controller(routeController);
       // Then
-      expect(result).toEqual({
-        connect: routeController,
-        controller: true,
-      });
+      expect(result).toBe(routeController);
+      expect(resource).toHaveBeenCalledTimes(1);
+      expect(resource).toHaveBeenCalledWith('controller', 'connect', routeController);
     });
 
     it('should create a route controller creator', () => {
       // Given
       const routeController = 'routeController';
-      const creatorFn = jest.fn(() => routeController);
-      const options = 'options';
-      let creator = null;
+      resourceCreator.mockImplementationOnce((_, __, fn) => fn);
       let result = null;
       // When
-      creator = controllerCreator(creatorFn);
-      result = creator(options);
+      result = controllerCreator(routeController);
       // Then
-      expect(result).toEqual({
-        connect: routeController,
-        controller: true,
-      });
-      expect(creatorFn).toHaveBeenCalledTimes(1);
-      expect(creatorFn).toHaveBeenCalledWith(options);
-    });
-
-    it('should create a route controller creator that can be used without options', () => {
-      // Given
-      const routeController = 'routeController';
-      const creatorFn = jest.fn(() => routeController);
-      let creator = null;
-      // When
-      creator = controllerCreator(creatorFn);
-      // Then
-      expect(creator.connect).toBe(routeController);
-      expect(creator.controller).toBeTrue();
-      expect(creatorFn).toHaveBeenCalledTimes(1);
-      expect(creatorFn).toHaveBeenCalledWith();
+      expect(result).toBe(routeController);
+      expect(resourceCreator).toHaveBeenCalledTimes(1);
+      expect(resourceCreator).toHaveBeenCalledWith('controller', 'connect', routeController);
     });
   });
 
   describe('middleware', () => {
-    it('should create a route middleware with a `connect` function', () => {
+    beforeEach(() => {
+      resource.mockReset();
+      resourceCreator.mockReset();
+    });
+
+    it('should create a route middleware', () => {
       // Given
       const appMiddleware = 'appMiddleware';
+      resource.mockImplementationOnce((_, __, fn) => fn);
       let result = null;
       // When
       result = middleware(appMiddleware);
       // Then
-      expect(result).toEqual({
-        connect: appMiddleware,
-        middleware: true,
-      });
+      expect(result).toBe(appMiddleware);
+      expect(resource).toHaveBeenCalledTimes(1);
+      expect(resource).toHaveBeenCalledWith('middleware', 'connect', appMiddleware);
     });
 
     it('should create a route middleware creator', () => {
       // Given
       const appMiddleware = 'appMiddleware';
-      const creatorFn = jest.fn(() => appMiddleware);
-      const options = 'options';
-      let creator = null;
+      resourceCreator.mockImplementationOnce((_, __, fn) => fn);
       let result = null;
       // When
-      creator = middlewareCreator(creatorFn);
-      result = creator(options);
+      result = middlewareCreator(appMiddleware);
       // Then
-      expect(result).toEqual({
-        connect: appMiddleware,
-        middleware: true,
-      });
-      expect(creatorFn).toHaveBeenCalledTimes(1);
-      expect(creatorFn).toHaveBeenCalledWith(options);
-    });
-
-    it('should create a route middleware creator that can be used without options', () => {
-      // Given
-      const appMiddleware = 'appMiddleware';
-      const creatorFn = jest.fn(() => appMiddleware);
-      let creator = null;
-      // When
-      creator = middlewareCreator(creatorFn);
-      // Then
-      expect(creator.connect).toBe(appMiddleware);
-      expect(creator.middleware).toBeTrue();
-      expect(creatorFn).toHaveBeenCalledTimes(1);
-      expect(creatorFn).toHaveBeenCalledWith();
+      expect(result).toBe(appMiddleware);
+      expect(resourceCreator).toHaveBeenCalledTimes(1);
+      expect(resourceCreator).toHaveBeenCalledWith('middleware', 'connect', appMiddleware);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,9 +281,9 @@
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.10.3", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.2.tgz#0882ab8a455df3065ea2dcb4c753b2460a24bead"
-  integrity sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==
+  version "7.11.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.3.tgz#9e1eae46738bcd08e23e867bab43e7b95299a8f9"
+  integrity sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.3":
   version "7.10.5"
@@ -1769,9 +1769,9 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001111:
-  version "1.0.30001111"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz#dd0ce822c70eb6c7c068e4a55c22e19ec1501298"
-  integrity sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg==
+  version "1.0.30001112"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001112.tgz#0fffc3b934ff56ff0548c37bc9dad7d882bcf672"
+  integrity sha512-J05RTQlqsatidif/38aN3PGULCLrg8OYQOlJUKbeYVzC2mGZkZLIztwRlB3MtrfLmawUmjFlNJvy/uhwniIe1Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2449,9 +2449,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.523:
-  version "1.3.523"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.523.tgz#494080b318ba929614eebd04405b94c359ea9333"
-  integrity sha512-D4/3l5DpciddD92IDRtpLearQSGzly8FwBJv+nITvLH8YJrFabpDFe4yuiOJh2MS4/EsXqyQTXyw1toeYPtshQ==
+  version "1.3.526"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.526.tgz#0e004899edf75afc172cce1b8189aac5dca646aa"
+  integrity sha512-HiroW5ZbGwgT8kCnoEO8qnGjoTPzJxduvV/Vv/wH63eo2N6Zj3xT5fmmaSPAPUM05iN9/5fIEkIg3owTtV6QZg==
 
 emittery@^0.7.1:
   version "0.7.1"
@@ -2716,17 +2716,17 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
-eslint-plugin-homer0@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-homer0/-/eslint-plugin-homer0-5.0.1.tgz#134f84137da40ca12345b27dffbc4eeecef82b3e"
-  integrity sha512-swQTYWlYMUoK8zGMPCRf2+8ttK4U19ZozGbZ9mMWEhlzV60wlI/emY7s/LpVe59gibOTNa9OrO9cCwEGxbjTuw==
+eslint-plugin-homer0@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-homer0/-/eslint-plugin-homer0-5.0.2.tgz#d81c01e3760e762e417ff9ecef24a2392f324108"
+  integrity sha512-bRGGdVPaBJNFcuXN6h4kXxbe39tFWoS8E6+389QnEZr44dID6i2D4lJSVOt5P/Z7kQRnnPNb6VfCdgAkAyyF2A==
   dependencies:
-    eslint "^7.5.0"
+    eslint "^7.6.0"
     eslint-config-airbnb-base "^14.2.0"
     eslint-plugin-import "^2.22.0"
-    eslint-plugin-jsdoc "^30.0.3"
+    eslint-plugin-jsdoc "^30.2.1"
     eslint-plugin-node "^11.1.0"
-    eslint-plugin-sort-class-members "^1.7.0"
+    eslint-plugin-sort-class-members "^1.8.0"
 
 eslint-plugin-import@^2.22.0:
   version "2.22.0"
@@ -2747,7 +2747,7 @@ eslint-plugin-import@^2.22.0:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-jsdoc@^30.0.3:
+eslint-plugin-jsdoc@^30.2.1:
   version "30.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.2.1.tgz#6cac1a70ec239b4672888193d8a4e084a7e2d7bf"
   integrity sha512-9Nx+BKMBoCTDRIbVpMV4MYfw+lvfnfsWTWYX9vwRRZrkXBpZkKtE3dsFcG6MhF7N/vW1cwpjEnoAIAtn0+a6gw==
@@ -2772,10 +2772,10 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-plugin-sort-class-members@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.7.0.tgz#82b8bfd1bf4bf4a4766b67e816359085a49b1dc3"
-  integrity sha512-p9VeMf4lwJs4VJ9jDJRadXPklNGIdUYxeCLi0tjF3F83KNC6CfX+c3H2h0DQ2yLl3hgKf0j6s3wGpZUuRYToeA==
+eslint-plugin-sort-class-members@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.8.0.tgz#92bcc0f88e9b9ebced01d45b631319f8485477f4"
+  integrity sha512-2DY2xgmcpHeTYgXrkAV2b7rQI1+6PhuAn/KWwU9ttiUF8V/V7dgu48Eru/67GfAPs+p6H6XDlaT2NjBpH2l+Qg==
 
 eslint-scope@^5.1.0:
   version "5.1.0"
@@ -2797,7 +2797,7 @@ eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint@^7.5.0, eslint@^7.6.0:
+eslint@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.6.0.tgz#522d67cfaea09724d96949c70e7a0550614d64d6"
   integrity sha512-QlAManNtqr7sozWm5TF4wIH9gmUm2hE3vNRUvyoYAa4y1l5/jxD/PQStEjBMQtCqZmSep8UxrcecI60hOpe61w==
@@ -3273,9 +3273,9 @@ get-stream@^4.0.0:
     pump "^3.0.0"
 
 get-stream@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
-  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
 
@@ -4330,9 +4330,9 @@ jsdoctypeparser@^9.0.0:
   integrity sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==
 
 jsdom@^16.2.2:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.3.0.tgz#75690b7dac36c67be49c336dcd7219bbbed0810c"
-  integrity sha512-zggeX5UuEknpdZzv15+MS1dPYG0J/TftiiNunOeNxSl3qr8Z6cIlQpN0IdJa44z9aFxZRIVqRncvEhQ7X5DtZg==
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.4.0.tgz#36005bde2d136f73eee1a830c6d45e55408edddb"
+  integrity sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==
   dependencies:
     abab "^2.0.3"
     acorn "^7.1.1"
@@ -5128,9 +5128,9 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
     wrappy "1"
 
 onetime@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.1.tgz#5c8016847b0d67fcedb7eef254751cfcdc7e9418"
-  integrity sha512-ZpZpjcJeugQfWsfyQlshVoowIIQ1qBGSVll4rfDq6JJVO//fesjoX808hXWfBjY+ROZgpKDI5TRSRBSoJiZ8eg==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
 
@@ -6760,10 +6760,10 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-wootils@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/wootils/-/wootils-4.0.0.tgz#0f9afe3a50ee841f7492af054d7931095df2909c"
-  integrity sha512-+9EFch5vXbYtK8ykD4O/+UsTjRLRkog1v0m7XGA8gFlxL8NLbFAq/1HSeGvr+AjB8GsynjTNsZXtc/1FY6swNQ==
+wootils@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/wootils/-/wootils-4.0.1.tgz#0d7a8257aadd6b932ce94e4d4414922824ab2416"
+  integrity sha512-9TrnIavysaZTCDZwzJ9tvPnJjaYkgafiyMR5DQ3pTe2zx0GdFbKGdKX5r4g+JHpCONEzZb6zQp0I7Z+d+EWJPQ==
   dependencies:
     colors "^1.4.0"
     extend "^3.0.2"


### PR DESCRIPTION
### What does this PR do?

On Olapic/wootils#69, I moved the wrappers for `resource`, `resourceCreator` and `resources`, used on this project, to `wootils`, as I needed them for other projects no-Jimpex too.

On this PR, I'm removing them from this project so it can start using them directly from `wootils`.

### How should it be tested manually?

This is not breaking, the wrappers work the same way as they did before.

And, don't forget to...

```bash
yarn lint:all
# or
npm run lint:all
```