### PR TITLE
07 - Start jimpex with a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "eslint-plugin-homer0": "^5.0.2",
     "jest": "^26.4.2",
     "jsdoc": "^3.6.5",
-    "jsdoc-ts-utils": "^1.0.1",
+    "jsdoc-ts-utils": "^1.1.1",
     "docdash": "homer0/docdash#semver:^2.1.0",
     "leasot": "^11.1.0",
-    "lint-staged": "^10.2.11",
+    "lint-staged": "^10.2.13",
     "husky": "^4.2.5"
   },
   "engine-strict": true,

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -45,15 +45,8 @@ class Jimpex extends Jimple {
    *                                              services/middlewares/controllers before the
    *                                              application starts.
    * @param {Partial<JimpexOptions>} [options={}] Preferences to customize the application.
-   * @throws {TypeError} If instantiated directly.
    */
   constructor(boot = true, options = {}) {
-    if (new.target === Jimpex) {
-      throw new TypeError(
-        'Jimpex is an abstract class, it can\'t be instantiated directly',
-      );
-    }
-
     super();
     /**
      * The application options.
@@ -153,13 +146,8 @@ class Jimpex extends Jimple {
   }
   /**
    * This is where the app would register all its specific services, middlewares and controllers.
-   *
-   * @throws {Error} If not overwritten.
-   * @abstract
    */
-  boot() {
-    throw new Error('This method must be overwritten');
-  }
+  boot() {}
   /**
    * Disables the server TLS validation.
    */

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -603,5 +603,18 @@ class Jimpex extends Jimple {
     this.set('router', this.factory(() => express.Router()));
   }
 }
+/**
+ * Creates a new instance of {@link Jimpex}.
+ *
+ * @param {Partial<JimpexOptions>} [options={}]         Preferences to customize the application.
+ * @param {?Object}                [configuration=null] The default configuration for the
+ *                                                      `appConfiguration` service.
+ * @returns {Jimpex}
+ */
+const jimpex = (options = {}, configuration = null) => new Jimpex(
+  options,
+  configuration,
+);
 
-module.exports = Jimpex;
+module.exports.Jimpex = Jimpex;
+module.exports.jimpex = jimpex;

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const https = require('https');
 const Jimple = require('jimple');
 const ObjectUtils = require('wootils/shared/objectUtils');
@@ -38,9 +39,11 @@ const { escapeForRegExp } = require('../utils/functions');
  */
 class Jimpex extends Jimple {
   /**
-   * @param {Partial<JimpexOptions>} [options={}] Preferences to customize the application.
+   * @param {Partial<JimpexOptions>} [options={}]         Preferences to customize the application.
+   * @param {?Object}                [configuration=null] The default configuration for the
+   *                                                      `appConfiguration` service.
    */
-  constructor(options = {}) {
+  constructor(options = {}, configuration = null) {
     super();
     /**
      * The application options.
@@ -54,7 +57,7 @@ class Jimpex extends Jimple {
       filesizeLimit: '15MB',
       boot: true,
       configuration: {
-        default: null,
+        default: configuration,
         name: 'app',
         path: 'config/',
         hasFolder: true,
@@ -479,7 +482,7 @@ class Jimpex extends Jimple {
     if (options.default) {
       defaultConfig = options.default;
     } else {
-      const defaultConfigPath = `${configsPath}${options.name}.config.js`;
+      const defaultConfigPath = path.join(configsPath, `${options.name}.config.js`);
       defaultConfig = this.get('rootRequire')(defaultConfigPath);
     }
 

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -162,16 +162,22 @@ class Jimpex extends Jimple {
    * This is an alias of `start`. The idea is for it to be used on serverless platforms, where you
    * don't get to start your app, you just have export it.
    *
-   * @param {number}              port The port where the app will run. In case the rest of the app
-   *                                   needs to be aware of the port, this method will overwrite
-   *                                   the `port` setting on the configuration.
-   * @param {JimpexStartCallback} [fn] A callback function to be called when the server starts.
+   * @param {?number}              [port=null] In case the configuration doesn't already have it,
+   *                                           this is the port where the application will use to
+   *                                           run. If this parameter is used, the method will
+   *                                           overwrite the `port` setting on the configuration
+   *                                           service.
+   * @param {?JimpexStartCallback} [fn=null]   A callback function to be called when the server
+   *                                            starts.
    * @returns {Server} The server instance.
    */
-  listen(port, fn = () => {}) {
-    const config = this.get('appConfiguration');
-    config.set('port', port);
-    return this.start(fn, port);
+  listen(port = null, fn = null) {
+    if (port) {
+      const config = this.get('appConfiguration');
+      config.set('port', port);
+    }
+
+    return this.start(fn);
   }
   /**
    * Mounts a controller on a specific route.
@@ -204,10 +210,11 @@ class Jimpex extends Jimple {
   /**
    * Starts the app server.
    *
-   * @param {JimpexStartCallback} [fn] A callback function to be called when the server starts.
+   * @param {?JimpexStartCallback} [fn=null] A callback function to be called when the server
+   *                                         starts.
    * @returns {Object} The server instance.
    */
-  start(fn = () => {}) {
+  start(fn = null) {
     const config = this.get('appConfiguration');
     const port = config.get('port');
     this._emitEvent('beforeStart');
@@ -217,9 +224,10 @@ class Jimpex extends Jimple {
       this._mountResources();
       this.get('appLogger').success(`Starting on port ${port}`);
       this._emitEvent('afterStart');
-      const result = fn(config);
+      if (fn) {
+        fn(config);
+      }
       this._emitEvent('afterStartCallback');
-      return result;
     });
 
     return this._instance;

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -38,15 +38,9 @@ const { escapeForRegExp } = require('../utils/functions');
  */
 class Jimpex extends Jimple {
   /**
-   * @param {boolean}                [boot=true]  If `true`, after initializing the server, it will
-   *                                              immediately call the `boot` method. This can be
-   *                                              used on a development environment where you
-   *                                              would want to register development
-   *                                              services/middlewares/controllers before the
-   *                                              application starts.
    * @param {Partial<JimpexOptions>} [options={}] Preferences to customize the application.
    */
-  constructor(boot = true, options = {}) {
+  constructor(options = {}) {
     super();
     /**
      * The application options.
@@ -58,6 +52,7 @@ class Jimpex extends Jimple {
     this._options = ObjectUtils.merge({
       version: '0.0.0',
       filesizeLimit: '15MB',
+      boot: true,
       configuration: {
         default: null,
         name: 'app',
@@ -140,7 +135,7 @@ class Jimpex extends Jimple {
     this._setupDefaultServices();
     this._setupConfiguration();
 
-    if (boot) {
+    if (this._options.boot) {
       this.boot();
     }
   }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -627,7 +627,7 @@ class Jimpex extends Jimple {
  */
 const jimpex = (options = {}, configuration = null) => new Jimpex(
   options,
-  configuration,
+  configuration || {},
 );
 
 module.exports.Jimpex = Jimpex;

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -28,7 +28,6 @@ const { eventNames } = require('../constants');
 const commonServices = require('../services/common');
 const httpServices = require('../services/http');
 const utilsServices = require('../services/utils');
-const { escapeForRegExp } = require('../utils/functions');
 /**
  * Jimpex is a mix of Jimple, a Javascript port of Pimple dependency injection container, and
  * Express, one of the most popular web frameworks for Node.
@@ -241,23 +240,7 @@ class Jimpex extends Jimple {
    *                 exist.
    */
   try(name) {
-    let result;
-    try {
-      result = this.get(name);
-    } catch (error) {
-      /**
-       * Validate if the received error is from Jimple not being able to find the service, or from
-       * something else; if it's not about the module not being registered, throw the error.
-       */
-      const expression = new RegExp(escapeForRegExp(`identifier "${name}" is not defined`), 'i');
-      if (error.message && error.message.match(expression)) {
-        result = null;
-      } else {
-        throw error;
-      }
-    }
-
-    return result;
+    return this.has(name) ? this.get(name) : null;
   }
   /**
    * Adds a middleware.

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -51,39 +51,43 @@ class Jimpex extends Jimple {
      * @access protected
      * @ignore
      */
-    this._options = ObjectUtils.merge({
-      version: '0.0.0',
-      filesizeLimit: '15MB',
-      boot: true,
-      configuration: {
-        default: configuration,
-        name: 'app',
-        path: 'config/',
-        hasFolder: true,
-        environmentVariable: 'CONFIG',
-        loadFromEnvironment: true,
-        loadVersionFromConfiguration: true,
-        filenameFormat: '[app-name].[configuration-name].config.js',
+    this._options = ObjectUtils.merge(
+      {
+        version: '0.0.0',
+        filesizeLimit: '15MB',
+        boot: true,
+        configuration: {
+          default: configuration,
+          name: 'app',
+          path: 'config/',
+          hasFolder: true,
+          environmentVariable: 'CONFIG',
+          loadFromEnvironment: true,
+          loadVersionFromConfiguration: true,
+          filenameFormat: '[app-name].[configuration-name].config.js',
+        },
+        statics: {
+          enabled: true,
+          onHome: false,
+          route: 'statics',
+          folder: '',
+        },
+        express: {
+          trustProxy: true,
+          disableXPoweredBy: true,
+          compression: true,
+          bodyParser: true,
+          multer: true,
+        },
+        defaultServices: {
+          common: true,
+          http: true,
+          utils: true,
+        },
       },
-      statics: {
-        enabled: true,
-        onHome: false,
-        route: 'statics',
-        folder: '',
-      },
-      express: {
-        trustProxy: true,
-        disableXPoweredBy: true,
-        compression: true,
-        bodyParser: true,
-        multer: true,
-      },
-      defaultServices: {
-        common: true,
-        http: true,
-        utils: true,
-      },
-    }, options);
+      options,
+      this._initOptions(),
+    );
     /**
      * The Express application Jimpex uses under the hood.
      *
@@ -137,6 +141,7 @@ class Jimpex extends Jimple {
     this._setupDefaultServices();
     this._setupConfiguration();
 
+    this._init();
     if (this._options.boot) {
       this.boot();
     }
@@ -386,6 +391,32 @@ class Jimpex extends Jimple {
     }
 
     return result;
+  }
+  /**
+   * This method is like a "lifecycle method", it gets executed on the constructor right before
+   * the "boot step". The idea is for the method to be a helper when application is defined by
+   * subclassing {@link Jimpex}: the application could register all important services here and
+   * the routes on boot, then, if the implementation needs to access or overwrite a something, it
+   * can send `boot: false`, access/register what it needs and then call `boot()`. That would be
+   * impossible for an application without overwriting the constructor and the boot functionality.
+   *
+   * @access protected
+   */
+  _init() {}
+  /**
+   * It generates overwrites for the class options when they are created. This method is a helper
+   * for when the application is defined by subclassing {@link Jimpex}: It's highly probable that
+   * if the application needs to change the default options, it would want to do it right from the
+   * class, instead of having to do it on every implementation. A way to do it would be overwriting
+   * the constructor and calling `super` with the custom overwrites; this method exists so that
+   * won't be necessary: when creating the `options`, the constructor will merge the result of
+   * this method on top of the default ones.
+   *
+   * @returns {Partial<JimpexOptions>}
+   * @access protected
+   */
+  _initOptions() {
+    return {};
   }
   /**
    * Loads the contents of a dictionary of files that need to be used for HTTPS credentials.

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const Jimpex = require('./app');
+const { Jimpex, jimpex } = require('./app');
 const controllers = require('./controllers');
 const middlewares = require('./middlewares');
 const services = require('./services');
@@ -27,3 +27,4 @@ module.exports.services = services;
 module.exports.eventNames = eventNames;
 module.exports.utils = utils;
 module.exports.Jimpex = Jimpex;
+module.exports.jimpex = jimpex;

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -222,12 +222,15 @@
  * @typedef {Object} JimpexOptions
  * @property {string}                       version         The app version. To be used on the
  *                                                          configuration. Default `'0.0.0'`.
+ * @property {string}                       filesizeLimit   The size limit for the requests
+ *                                                          payload. Default `'15MB'`.
+ * @property {boolean}                      boot            Whether or not to automatically call
+ *                                                          the `boot` method after initialization.
+ *                                                          Default `true`.
  * @property {JimpexConfigurationOptions}   configuration   The options for the app configuration
  *                                                          service.
  * @property {JimpexStaticsOptions}         statics         The options for the app static
  *                                                          `middleware`.
- * @property {string}                       filesizeLimit   The size limit for the requests
- *                                                          payload. Default `'15MB'`.
  * @property {JimpexExpressOptions}         express         The options for the Express app.
  * @property {JimpexDefaultServicesOptions} defaultServices To tell the app which services should
  *                                                          be registered when instantiated.

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -237,7 +237,7 @@
  */
 
 /**
- * @typedef {import('./app')} Jimpex
+ * @typedef {import('./app').Jimpex} Jimpex
  */
 
 /**

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -1737,11 +1737,7 @@ describe('app:Jimpex', () => {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
     JimpleMock.service('pathUtils', pathUtils);
-    const defaultConfig = {
-      port: 2509,
-    };
-    const rootRequire = jest.fn(() => defaultConfig);
-    JimpleMock.service('rootRequire', rootRequire);
+    JimpleMock.service('rootRequire', jest.fn());
     const version = 'latest';
     const appConfiguration = {
       loadFromEnvironment: jest.fn(),
@@ -1756,7 +1752,7 @@ describe('app:Jimpex', () => {
     expect(wootilsMock.appConfiguration).toHaveBeenCalledTimes(1);
     expect(wootilsMock.appConfiguration).toHaveBeenCalledWith({
       appName: sut.options.configuration.name,
-      defaultConfiguration: defaultConfig,
+      defaultConfiguration: {},
       options: {
         environmentVariable: sut.options.configuration.environmentVariable,
         path: `${sut.options.configuration.path}${sut.options.configuration.name}/`,

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -148,9 +148,13 @@ describe('app:Jimpex', () => {
   it('should call a custom boot method when subclassed', () => {
     // Given
     const bootMock = jest.fn();
+    const initMock = jest.fn();
     class Sut extends Jimpex {
       boot() {
         bootMock();
+      }
+      _init() {
+        initMock();
       }
     }
     const pathUtils = {
@@ -175,14 +179,19 @@ describe('app:Jimpex', () => {
     expect(sut).toBeInstanceOf(Sut);
     expect(sut).toBeInstanceOf(Jimpex);
     expect(bootMock).toHaveBeenCalledTimes(1);
+    expect(initMock).toHaveBeenCalledTimes(1);
   });
 
   it('shouldn\'t call `boot` is option is set to false', () => {
     // Given
     const bootMock = jest.fn();
+    const initMock = jest.fn();
     class Sut extends Jimpex {
       boot() {
         bootMock();
+      }
+      _init() {
+        initMock();
       }
     }
     const pathUtils = {
@@ -204,6 +213,42 @@ describe('app:Jimpex', () => {
     });
     // Then
     expect(bootMock).toHaveBeenCalledTimes(0);
+    expect(initMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should overwrite the default options using the protected method', () => {
+    // Given
+    class Sut extends Jimpex {
+      _initOptions() {
+        return {
+          configuration: {
+            loadFromEnvironment: false,
+          },
+        };
+      }
+    }
+    const pathUtils = {
+      joinFrom: jest.fn((from, rest) => path.join(from, rest)),
+    };
+    JimpleMock.service('pathUtils', pathUtils);
+    const defaultConfig = {
+      port: 2509,
+    };
+    const rootRequire = jest.fn(() => defaultConfig);
+    JimpleMock.service('rootRequire', rootRequire);
+    const version = 'latest';
+    const appConfiguration = {
+      loadFromEnvironment: jest.fn(),
+      get: jest.fn(() => version),
+    };
+    JimpleMock.service('appConfiguration', appConfiguration);
+    let sut = null;
+    // When
+    sut = new Sut();
+    // Then
+    expect(sut).toBeInstanceOf(Sut);
+    expect(sut).toBeInstanceOf(Jimpex);
+    expect(appConfiguration.loadFromEnvironment).toHaveBeenCalledTimes(0);
   });
 
   it('shouldn\'t set \'trust proxy\' if its flag is `false`', () => {

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -604,6 +604,39 @@ describe('app:Jimpex', () => {
     expect(appConfiguration.loadFromEnvironment).toHaveBeenCalledTimes(1);
   });
 
+  it('should receive the default configuration from the constructor parameter', () => {
+    // Given
+    const pathUtils = {
+      joinFrom: jest.fn((from, rest) => path.join(from, rest)),
+    };
+    JimpleMock.service('pathUtils', pathUtils);
+    const version = 'version-on-file';
+    const appConfiguration = {
+      loadFromEnvironment: jest.fn(),
+      get: jest.fn(() => version),
+    };
+    JimpleMock.service('appConfiguration', appConfiguration);
+    const defaultConfiguration = {
+      charito: 25092015,
+    };
+    let sut = null;
+    // When
+    sut = new Jimpex({}, defaultConfiguration);
+    // Then
+    expect(wootilsMock.appConfiguration).toHaveBeenCalledTimes(1);
+    expect(wootilsMock.appConfiguration).toHaveBeenCalledWith({
+      appName: sut.options.configuration.name,
+      defaultConfiguration,
+      options: {
+        environmentVariable: sut.options.configuration.environmentVariable,
+        path: `${sut.options.configuration.path}${sut.options.configuration.name}/`,
+        filenameFormat: `${sut.options.configuration.name}.[name].config.js`,
+      },
+    });
+    expect(appConfiguration.loadFromEnvironment).toHaveBeenCalledTimes(1);
+    expect(sut.options.version).toBe(version);
+  });
+
   it('should receive the default configuration on the configuration options', () => {
     // Given
     const pathUtils = {

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -177,7 +177,7 @@ describe('app:Jimpex', () => {
     expect(bootMock).toHaveBeenCalledTimes(1);
   });
 
-  it('shouldn\'t call `boot` is the constructor flag is false', () => {
+  it('shouldn\'t call `boot` is option is set to false', () => {
     // Given
     const bootMock = jest.fn();
     class Sut extends Jimpex {
@@ -199,16 +199,15 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     // When
     // eslint-disable-next-line no-new
-    new Sut(false);
+    new Sut({
+      boot: false,
+    });
     // Then
     expect(bootMock).toHaveBeenCalledTimes(0);
   });
 
   it('shouldn\'t set \'trust proxy\' if its flag is `false`', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -223,7 +222,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     // When
     // eslint-disable-next-line no-new
-    new Sut(true, {
+    new Jimpex({
       express: {
         trustProxy: false,
       },
@@ -234,9 +233,6 @@ describe('app:Jimpex', () => {
 
   it('shouldn\'t remove the \'x-powered-by\' if its flag is `false`', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -251,7 +247,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     // When
     // eslint-disable-next-line no-new
-    new Sut(true, {
+    new Jimpex({
       express: {
         disableXPoweredBy: false,
       },
@@ -262,9 +258,6 @@ describe('app:Jimpex', () => {
 
   it('shouldn\'t add the compression middleware if its flag is `false`', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -279,7 +272,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     // When
     // eslint-disable-next-line no-new
-    new Sut(true, {
+    new Jimpex({
       express: {
         compression: false,
       },
@@ -290,9 +283,6 @@ describe('app:Jimpex', () => {
 
   it('shouldn\'t add the bodyParser middleware if its flag is `false`', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -307,7 +297,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     // When
     // eslint-disable-next-line no-new
-    new Sut(true, {
+    new Jimpex({
       express: {
         bodyParser: false,
       },
@@ -319,9 +309,6 @@ describe('app:Jimpex', () => {
 
   it('shouldn\'t add the multer middleware if its flag is `false`', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -336,7 +323,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     // When
     // eslint-disable-next-line no-new
-    new Sut(true, {
+    new Jimpex({
       express: {
         multer: false,
       },
@@ -348,9 +335,6 @@ describe('app:Jimpex', () => {
 
   it('shouldn\'t add the static middleware if its flag is `false`', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -365,7 +349,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     // When
     // eslint-disable-next-line no-new
-    new Sut(true, {
+    new Jimpex({
       statics: {
         enabled: false,
       },
@@ -380,9 +364,6 @@ describe('app:Jimpex', () => {
      * Home directory: Where the app is executed from (`process.cwd`).
      */
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -397,7 +378,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     let sut = null;
     // When
-    sut = new Sut(true, {
+    sut = new Jimpex({
       statics: {
         onHome: true,
       },
@@ -414,9 +395,6 @@ describe('app:Jimpex', () => {
      * Home directory: Where the app is executed from (`process.cwd`).
      */
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -440,7 +418,7 @@ describe('app:Jimpex', () => {
       ['multer-any'],
     ];
     // When
-    sut = new Sut(true, {
+    sut = new Jimpex({
       statics: {
         onHome: true,
         route: staticsRoute,
@@ -494,7 +472,7 @@ describe('app:Jimpex', () => {
       [`/${customStatic}`, path.join('app', customStatic)],
     ];
     // When
-    sut = new Sut(true, {
+    sut = new Sut({
       statics: {
         onHome: true,
         route: staticsRoute,
@@ -515,9 +493,6 @@ describe('app:Jimpex', () => {
 
   it('shouldn\'t add the default services if their flags are `false`', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -540,7 +515,7 @@ describe('app:Jimpex', () => {
       'appConfiguration',
     ];
     // When
-    sut = new Sut(true, {
+    sut = new Jimpex({
       defaultServices: {
         common: false,
         http: false,
@@ -556,9 +531,6 @@ describe('app:Jimpex', () => {
 
   it('should be able to look for configurations', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -574,7 +546,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     let sut = null;
     // When
-    sut = new Sut(true, {
+    sut = new Jimpex({
       configuration: {
         hasFolder: false,
       },
@@ -596,9 +568,6 @@ describe('app:Jimpex', () => {
 
   it('should inject the app version on the default configuration', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -614,7 +583,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appConfiguration', appConfiguration);
     let sut = null;
     // When
-    sut = new Sut(true, {
+    sut = new Jimpex({
       version,
       configuration: {
         hasFolder: false,
@@ -637,9 +606,6 @@ describe('app:Jimpex', () => {
 
   it('should receive the default configuration on the configuration options', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -655,7 +621,7 @@ describe('app:Jimpex', () => {
     };
     let sut = null;
     // When
-    sut = new Sut(true, {
+    sut = new Jimpex({
       configuration: {
         default: defaultConfiguration,
       },
@@ -677,9 +643,6 @@ describe('app:Jimpex', () => {
 
   it('shouldn\'t load the configuration based on an env var if the option is disabled', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -695,7 +658,7 @@ describe('app:Jimpex', () => {
     };
     let sut = null;
     // When
-    sut = new Sut(true, {
+    sut = new Jimpex({
       configuration: {
         default: defaultConfiguration,
         loadFromEnvironment: false,
@@ -718,9 +681,6 @@ describe('app:Jimpex', () => {
 
   it('should disable TL validation', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -739,7 +699,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appLogger', appLogger);
     let sut = null;
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.disableTLSValidation();
     // Then
     expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
@@ -749,9 +709,6 @@ describe('app:Jimpex', () => {
 
   it('should start and stop the server', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -786,7 +743,7 @@ describe('app:Jimpex', () => {
       eventNames.afterStop,
     ];
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.start();
     runningInstance = sut.instance;
     sut.stop();
@@ -811,9 +768,6 @@ describe('app:Jimpex', () => {
 
   it('should start the server and fire a custom callback', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -840,7 +794,7 @@ describe('app:Jimpex', () => {
     const callback = jest.fn();
     let sut = null;
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.start(callback);
     // Then
     expect(callback).toHaveBeenCalledTimes(1);
@@ -849,9 +803,6 @@ describe('app:Jimpex', () => {
 
   it('should start and stop the server with HTTPS enabled', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const files = {
       keyFile: {
         name: 'key-file',
@@ -902,7 +853,7 @@ describe('app:Jimpex', () => {
     let sut = null;
     let runningInstance = null;
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.start();
     runningInstance = sut.instance;
     sut.stop();
@@ -931,9 +882,6 @@ describe('app:Jimpex', () => {
 
   it('should start and stop the server with HTTPS and HTTP2 enabled', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const files = {
       keyFile: {
         name: 'key-file',
@@ -987,7 +935,7 @@ describe('app:Jimpex', () => {
     let sut = null;
     let runningInstance = null;
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.start();
     runningInstance = sut.instance;
     sut.stop();
@@ -1016,9 +964,6 @@ describe('app:Jimpex', () => {
 
   it('should send custom options to Spdy for HTTP2', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const files = {
       keyFile: {
         name: 'key-file',
@@ -1077,7 +1022,7 @@ describe('app:Jimpex', () => {
     let sut = null;
     let runningInstance = null;
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.start();
     runningInstance = sut.instance;
     sut.stop();
@@ -1107,9 +1052,6 @@ describe('app:Jimpex', () => {
 
   it('should throw an error if HTTPS is enabled but there are no credentials', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1142,15 +1084,12 @@ describe('app:Jimpex', () => {
     };
     JimpleMock.service('appLogger', appLogger);
     // When/Then
-    expect(() => new Sut().start())
+    expect(() => new Jimpex().start())
     .toThrow(/The `credentials` object on the HTTPS settings is missing/i);
   });
 
   it('should throw an error if HTTP2 is enabled but HTTPS is not', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1185,15 +1124,12 @@ describe('app:Jimpex', () => {
     };
     JimpleMock.service('appLogger', appLogger);
     // When/Then
-    expect(() => new Sut().start())
+    expect(() => new Jimpex().start())
     .toThrow(/HTTP2 requires for HTTPS to be enabled/i);
   });
 
   it('should throw an error if HTTPS is enabled but there are no credentials', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1227,15 +1163,12 @@ describe('app:Jimpex', () => {
     };
     JimpleMock.service('appLogger', appLogger);
     // When/Then
-    expect(() => new Sut().start())
+    expect(() => new Jimpex().start())
     .toThrow(/No credentials were found for HTTPS/i);
   });
 
   it('should start the server using `listen`', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1270,7 +1203,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appLogger', appLogger);
     let sut = null;
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.listen(customPort);
     // Then
     expect(appLogger.success).toHaveBeenCalledTimes(1);
@@ -1282,9 +1215,6 @@ describe('app:Jimpex', () => {
 
   it('should start the server using `listen` and fire a custom callback', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1320,7 +1250,7 @@ describe('app:Jimpex', () => {
     const callback = jest.fn();
     let sut = null;
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.listen(customPort, callback);
     // Then
     expect(callback).toHaveBeenCalledTimes(1);
@@ -1334,9 +1264,6 @@ describe('app:Jimpex', () => {
 
   it('shouldn\'t do anything when trying to stop the server without starting it', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1362,7 +1289,7 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appLogger', appLogger);
     let sut = null;
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.stop();
     // Then
     expect(expressMock.mocks.closeInstance).toHaveBeenCalledTimes(0);
@@ -1370,9 +1297,6 @@ describe('app:Jimpex', () => {
 
   it('should try to access a service that may or may not be registered', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1400,7 +1324,7 @@ describe('app:Jimpex', () => {
     let resultAvailable = null;
     let resultUnavailable = null;
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     resultAvailable = sut.try('events');
     resultUnavailable = sut.try('randomService');
     // Then
@@ -1410,9 +1334,6 @@ describe('app:Jimpex', () => {
 
   it('should throw an error when trying to access a service that failed to init', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1439,15 +1360,12 @@ describe('app:Jimpex', () => {
     JimpleMock.service('appLogger', appLogger);
     let sut = null;
     // When/Then
-    sut = new Sut();
+    sut = new Jimpex();
     expect(() => sut.try('events')).toThrow(error.message);
   });
 
   it('should mount a controller', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1499,7 +1417,7 @@ describe('app:Jimpex', () => {
       [eventNames.afterStartCallback],
     ];
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.mount(route, controller);
     sut.start();
     routesList = sut.routes;
@@ -1525,9 +1443,6 @@ describe('app:Jimpex', () => {
 
   it('should mount a controller router', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1579,7 +1494,7 @@ describe('app:Jimpex', () => {
       [eventNames.afterStartCallback],
     ];
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.mount(route, controller);
     sut.start();
     routesList = sut.routes;
@@ -1605,9 +1520,6 @@ describe('app:Jimpex', () => {
 
   it('should mount a middleware', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1650,7 +1562,7 @@ describe('app:Jimpex', () => {
       [middlewareFn],
     ];
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.use(middleware);
     sut.start();
     // Then
@@ -1669,9 +1581,6 @@ describe('app:Jimpex', () => {
 
   it('should mount an Express middleware', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1711,7 +1620,7 @@ describe('app:Jimpex', () => {
       [middleware],
     ];
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.use(middleware);
     sut.start();
     // Then
@@ -1730,9 +1639,6 @@ describe('app:Jimpex', () => {
 
   it('shouldn\'t mount a middleware if its `connect` method returned a falsy value', () => {
     // Given
-    class Sut extends Jimpex {
-      boot() {}
-    }
     const pathUtils = {
       joinFrom: jest.fn((from, rest) => path.join(from, rest)),
     };
@@ -1769,7 +1675,7 @@ describe('app:Jimpex', () => {
       ['multer-any'],
     ];
     // When
-    sut = new Sut();
+    sut = new Jimpex();
     sut.use(middleware);
     sut.start();
     // Then

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -1365,38 +1365,6 @@ describe('app:Jimpex', () => {
     expect(resultUnavailable).toBeNull();
   });
 
-  it('should throw an error when trying to access a service that failed to init', () => {
-    // Given
-    const pathUtils = {
-      joinFrom: jest.fn((from, rest) => path.join(from, rest)),
-    };
-    JimpleMock.service('pathUtils', pathUtils);
-    const defaultConfig = {};
-    const rootRequire = jest.fn(() => defaultConfig);
-    JimpleMock.service('rootRequire', rootRequire);
-    const configuration = {
-      port: 2509,
-    };
-    const appConfiguration = {
-      loadFromEnvironment: jest.fn(),
-      get: jest.fn((prop) => (Array.isArray(prop) ? [] : configuration[prop])),
-    };
-    JimpleMock.service('appConfiguration', appConfiguration);
-    const error = new Error('Something went wrong!');
-    const events = () => {
-      throw error;
-    };
-    JimpleMock.service('events', events, true);
-    const appLogger = {
-      success: jest.fn(),
-    };
-    JimpleMock.service('appLogger', appLogger);
-    let sut = null;
-    // When/Then
-    sut = new Jimpex();
-    expect(() => sut.try('events')).toThrow(error.message);
-  });
-
   it('should mount a controller', () => {
     // Given
     const pathUtils = {

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -1254,6 +1254,44 @@ describe('app:Jimpex', () => {
     const defaultConfig = {};
     const rootRequire = jest.fn(() => defaultConfig);
     JimpleMock.service('rootRequire', rootRequire);
+    const configuration = {
+      port: 2509,
+    };
+    const appConfiguration = {
+      loadFromEnvironment: jest.fn(),
+      get: jest.fn((prop) => (
+        Array.isArray(prop) ?
+          [] :
+          configuration[prop]
+      )),
+    };
+    JimpleMock.service('appConfiguration', appConfiguration);
+    const events = {
+      emit: jest.fn(),
+    };
+    JimpleMock.service('events', events);
+    const appLogger = {
+      success: jest.fn(),
+    };
+    JimpleMock.service('appLogger', appLogger);
+    let sut = null;
+    // When
+    sut = new Jimpex();
+    sut.listen();
+    // Then
+    expect(appLogger.success).toHaveBeenCalledTimes(1);
+    expect(appLogger.success).toHaveBeenCalledWith(`Starting on port ${configuration.port}`);
+  });
+
+  it('should start the server using `listen` with a custom port', () => {
+    // Given
+    const pathUtils = {
+      joinFrom: jest.fn((from, rest) => path.join(from, rest)),
+    };
+    JimpleMock.service('pathUtils', pathUtils);
+    const defaultConfig = {};
+    const rootRequire = jest.fn(() => defaultConfig);
+    JimpleMock.service('rootRequire', rootRequire);
     const customPort = 8080;
     const configuration = {
       port: 2509,

--- a/tests/mocks/jimple.mock.js
+++ b/tests/mocks/jimple.mock.js
@@ -16,6 +16,7 @@ const mocks = {
   }),
   register: jest.fn(),
   factory: jest.fn((fn) => fn()),
+  has: jest.fn((name) => !!services[name]),
 };
 
 class JimpleMock {
@@ -48,6 +49,7 @@ class JimpleMock {
     this.get = mocks.get;
     this.register = mocks.register;
     this.factory = mocks.factory;
+    this.has = mocks.has;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,9 +563,9 @@
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/node@*":
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.0.tgz#7d4411bf5157339337d7cff864d9ff45f177b499"
-  integrity sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.1.tgz#fdf6f6c6c73d3d8eee9c98a9a0485bc524b048d7"
+  integrity sha512-HnYlg/BRF8uC1FyKRFZwRaCPTPYKa+6I8QiUZFLredaGOou481cgFS4wKRFyKvQtX8xudqkSdBczJHIYSQYKrQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -578,9 +578,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prettier@^2.0.0":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.2.tgz#5bb52ee68d0f8efa9cc0099920e56be6cc4e37f3"
-  integrity sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.0.tgz#5f96562c1075ee715a5b138f0b7f591c1f40f6b8"
+  integrity sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1092,7 +1092,7 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-truncate@2.1.0, cli-truncate@^2.1.0:
+cli-truncate@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
   integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
@@ -1167,6 +1167,11 @@ commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
+commander@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
+  integrity sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==
 
 comment-parser@^0.7.6:
   version "0.7.6"
@@ -1277,6 +1282,17 @@ cosmiconfig@^6.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.7.2"
+
+cosmiconfig@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
+  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -1515,7 +1531,7 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enquirer@^2.3.5:
+enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -1657,9 +1673,9 @@ eslint-plugin-import@^2.22.0:
     tsconfig-paths "^3.9.0"
 
 eslint-plugin-jsdoc@^30.2.1:
-  version "30.2.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.2.4.tgz#fab63c612d10f7f622ed6ebdd6d9919fc6cc4e0e"
-  integrity sha512-7TLp+1EK/ufnzlBUuzgDiPz5k2UUIa01cFkZTvvbJr8PE0iWVDqENg0yLhqGUYaZfYRFhHpqCML8SQR94omfrg==
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.3.0.tgz#11f169d6ab52c56c77aa68d1458f268655e16db4"
+  integrity sha512-RvDLH26ILwX2J60P7tlNdz5IlTFeC52TEFgAC12+nz/lOx4a7n3/hP8fBPFZrQP07WA1t9ZOO8H/i7cEs2BTnA==
   dependencies:
     comment-parser "^0.7.6"
     debug "^4.1.1"
@@ -1814,7 +1830,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^4.0.0, execa@^4.0.1:
+execa@^4.0.0, execa@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.3.tgz#0a34dabbad6d66100bd6f2c576c8669403f317f2"
   integrity sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==
@@ -2402,7 +2418,7 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-import-fresh@^3.0.0, import-fresh@^3.1.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -3126,10 +3142,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdoc-ts-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jsdoc-ts-utils/-/jsdoc-ts-utils-1.0.1.tgz#100028bd3e7a15467d0da182f82572c7ae79a3b9"
-  integrity sha512-FjP2nuwenZjAkgKV9wPFWWLLdkq7zwVO9pduApT1Jdl3KUP/bIKJMJmmL8fSc1KGk+/n68rAFXui6BxkUlPV4Q==
+jsdoc-ts-utils@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jsdoc-ts-utils/-/jsdoc-ts-utils-1.1.1.tgz#b2ad72ce5268c75ddce148762ff3ae084fd0ecec"
+  integrity sha512-szKlPqrYPw03ma3AJ/OJS1bdgZfvP2b0YoDXPphXBhWUsgBFlkHjLi4jTHhS4mDW/xf6lblnwyiGoZLIxgE0/Q==
   dependencies:
     jsdoc "^3.6.5"
 
@@ -3344,20 +3360,20 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-lint-staged@^10.2.11:
-  version "10.2.11"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.2.11.tgz#713c80877f2dc8b609b05bc59020234e766c9720"
-  integrity sha512-LRRrSogzbixYaZItE2APaS4l2eJMjjf5MbclRZpLJtcQJShcvUzKXsNeZgsLIZ0H0+fg2tL4B59fU9wHIHtFIA==
+lint-staged@^10.2.13:
+  version "10.2.13"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.2.13.tgz#b9c504683470edfc464b7d3fe3845a5a1efcd814"
+  integrity sha512-conwlukNV6aL9SiMWjFtDp5exeDnTMekdNPDZsKGnpfQuHcO0E3L3Bbf58lcR+M7vk6LpCilxDAVks/DDVBYlA==
   dependencies:
-    chalk "^4.0.0"
-    cli-truncate "2.1.0"
-    commander "^5.1.0"
-    cosmiconfig "^6.0.0"
+    chalk "^4.1.0"
+    cli-truncate "^2.1.0"
+    commander "^6.0.0"
+    cosmiconfig "^7.0.0"
     debug "^4.1.1"
     dedent "^0.7.0"
-    enquirer "^2.3.5"
-    execa "^4.0.1"
-    listr2 "^2.1.0"
+    enquirer "^2.3.6"
+    execa "^4.0.3"
+    listr2 "^2.6.0"
     log-symbols "^4.0.0"
     micromatch "^4.0.2"
     normalize-path "^3.0.0"
@@ -3365,10 +3381,10 @@ lint-staged@^10.2.11:
     string-argv "0.3.1"
     stringify-object "^3.3.0"
 
-listr2@^2.1.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.6.0.tgz#788a3d202978a1b8582062952cbc49272c8e206a"
-  integrity sha512-nwmqTJYQQ+AsKb4fCXH/6/UmLCEDL1jkRAdSn9M6cEUzoRGrs33YD/3N86gAZQnGZ6hxV18XSdlBcJ1GTmetJA==
+listr2@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.6.1.tgz#fbbabd8eea723924df7530042c1990b346e81706"
+  integrity sha512-1aPX9GkS+W0aHfPUDedJqeqj0DOe1605NaNoqdwEYw/UF2UbZgCIIMpXXZALeG/8xzwMBztguzQEubU5Xw1Qbw==
   dependencies:
     chalk "^4.1.0"
     cli-truncate "^2.1.0"
@@ -5262,13 +5278,13 @@ whatwg-mimetype@^2.3.0:
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
 whatwg-url@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.1.0.tgz#c628acdcf45b82274ce7281ee31dd3c839791771"
-  integrity sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.2.1.tgz#ed73417230784b281fb2a32c3c501738b46167c3"
+  integrity sha512-ZmVCr6nfBeaMxEHALLEGy0LszYjpJqf6PVNQUQ1qd9Et+q7Jpygd4rGGDXgHjD8e99yLFseD69msHDM4YwPZ4A==
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^2.0.2"
-    webidl-conversions "^5.0.0"
+    webidl-conversions "^6.1.0"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -5371,7 +5387,7 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
-yaml@^1.7.2:
+yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==


### PR DESCRIPTION
### What does this PR do?

`Jimpex` is not longer an abstract class and `boot` is not longer required... thanks to this, we now have the `jimpex` function that will allow us to create apps a lot fast:

```js
const { jimpex } = require('jimpex');

const app = jimpex();
app.use((res) => {
  app.get('responsesBuilder').json(res, { hello: 'world' });
});

app.listen(2509, () => {
  console.log('It works!');
});
```

But no, it doesn't mean that the library is going to migrate to this approach; this same PR adds two new features for the application extends the `Jimpex` class:

- `_init()`: A method to define custom services/resources that can be accessed before `boot()` and that gets executed right from the constructor, even if `boot()` is disabled.
- `_initOptions()`: This method allows you to overwrite the application default options without the need of overwriting the constructor or having to send the options on every implementation.

Now, there are a few breaking changes:

First, the signature of the constructor changed:

```diff
- constructor(boot = true, options = {}) {
+ constructor(options = {}, configuration = null) {
```

The `boot` parameter is now part of the options, and the second parameter is now the default configuration. Sending a default configuration means that the external configuration file won't be required, and having two define two level of options just to disable that was too much work.

On the other side, if you want to use `listen` to start the server and your configuration already includes the port, good news! the `port` parameter is not longer required, you can call `listen()` with no parameters.

And if you want the callback, you can pass any falsy value or just use `start()`.

But, there's a breaking change for those subclassing, as all parameters for `listen` and `start` are `null` by default now.

Read the changes on the `README` to get a better picture of the changes.

### How should it be tested manually?

Try the new function, and of course...

```bash
npm test;
# or
yarn test;
```