### PR TITLE
08 - Controller providers

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -264,10 +264,13 @@ class Jimpex extends Jimple {
    * @param {MiddlewareLike} middleware The middleware to use.
    */
   use(middleware) {
+    const useMiddleware = typeof middleware.register === 'function' ?
+      middleware.register(this) :
+      middleware;
     this._mountQueue.push((server) => {
-      if (typeof middleware.connect === 'function') {
+      if (typeof useMiddleware.connect === 'function') {
         // If the middleware is from Jimpex, connect it and then use it.
-        const middlewareHandler = middleware.connect(this);
+        const middlewareHandler = useMiddleware.connect(this);
         if (middlewareHandler) {
           server.use(this._reduceWithEvent(
             'middlewareWillBeUsed',
@@ -279,7 +282,7 @@ class Jimpex extends Jimple {
         // But if the middleware is a regular middleware, just use it directly.
         server.use(this._reduceWithEvent(
           'middlewareWillBeUsed',
-          middleware,
+          useMiddleware,
           null,
         ));
       }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -182,17 +182,20 @@ class Jimpex extends Jimple {
   /**
    * Mounts a controller on a specific route.
    *
-   * @param {string}     route      The route for the controller.
-   * @param {Controller} controller The route controller.
+   * @param {string}                        route      The route for the controller.
+   * @param {Controller|ControllerProvider} controller The route controller.
    */
   mount(route, controller) {
+    const useController = typeof controller.register === 'function' ?
+      controller.register(this, route) :
+      controller;
     this._mountQueue.push((server) => {
       let result;
       const routes = this._reduceWithEvent(
         'controllerWillBeMounted',
-        controller.connect(this, route),
+        useController.connect(this, route),
         route,
-        controller,
+        useController,
       );
       if (Array.isArray(routes)) {
         // If the returned value is a list of routes, mount each single route.

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -252,6 +252,24 @@
  */
 
 /**
+ * @callback ControllerProviderRegisterFn
+ * @param {Jimpex} app   The instance of the application container.
+ * @param {string} route The route where the controller will be mounted.
+ * @returns {Controller}
+ */
+
+/**
+ * This is a special kind of controller that not only registers routes but also adds resources to
+ * the container, and to avoid doing it during the mount process, it registers the resources first
+ * and then returns the actuall controller.
+ *
+ * @typedef {Object} ControllerProvider
+ * @property {ControllerProviderRegisterFn} register  The function Jimpex calls when registering
+ *                                                    the provider and the one that has to generate
+ *                                                    the controller.
+ */
+
+/**
  * The function called by the application container in order to mount a routes controller.
  *
  * @callback ControllerConnectFn
@@ -275,7 +293,7 @@
  *
  * @callback ControllerCreator
  * @param {Partial<O>} [options={}] The options to create the controller.
- * @returns {Controller}
+ * @returns {Controller|ControllerProvider}
  * @template O
  */
 

--- a/tests/controllers/utils/gateway.test.js
+++ b/tests/controllers/utils/gateway.test.js
@@ -1012,7 +1012,7 @@ describe('controllers/utils:gateway', () => {
     });
   });
 
-  describe('shorthand', () => {
+  describe('provider', () => {
     it('should register the routes and return the router', () => {
       // Given
       const gatewayConfig = {
@@ -1033,7 +1033,9 @@ describe('controllers/utils:gateway', () => {
       };
       const app = {
         get: jest.fn((name) => services[name] || name),
-        set: jest.fn(),
+        set: jest.fn((name, fn) => {
+          services[name] = fn();
+        }),
         try: jest.fn(),
       };
       const route = '/my-gateway';
@@ -1042,10 +1044,11 @@ describe('controllers/utils:gateway', () => {
       const expectedGetServices = [
         'appConfiguration',
         'http',
+        'apiGateway',
         'router',
       ];
       // When
-      result = gatewayController.connect(app, route);
+      result = gatewayController.register(app, route).connect();
       [[, service]] = app.set.mock.calls;
       // Then
       expect(result).toBe(router);
@@ -1087,22 +1090,25 @@ describe('controllers/utils:gateway', () => {
       };
       const app = {
         get: jest.fn((name) => services[name] || name),
-        set: jest.fn(),
+        set: jest.fn((name, fn) => {
+          services[name] = fn();
+        }),
         try: jest.fn(),
       };
       const route = '/my-gateway';
       let result = null;
       let service = null;
-      const expectedGetServices = [
-        'appConfiguration',
-        'http',
-        'router',
-      ];
       const options = {
         serviceName: 'myService',
       };
+      const expectedGetServices = [
+        'appConfiguration',
+        'http',
+        `${options.serviceName}Gateway`,
+        'router',
+      ];
       // When
-      result = gatewayController(options).connect(app, route);
+      result = gatewayController(options).register(app, route).connect();
       [[, service]] = app.set.mock.calls;
       // Then
       expect(result).toBe(router);
@@ -1144,24 +1150,27 @@ describe('controllers/utils:gateway', () => {
       };
       const app = {
         get: jest.fn((name) => services[name] || name),
-        set: jest.fn(),
+        set: jest.fn((name, fn) => {
+          services[name] = fn();
+        }),
         try: jest.fn(),
       };
       const route = '/my-gateway';
       let result = null;
       let service = null;
-      const expectedGetServices = [
-        'appConfiguration',
-        'http',
-        'router',
-      ];
       const options = {
         serviceName: 'myServiceGateway',
         configurationSetting: 'myConfigSetting',
         helperServiceName: 'myGatewayHelper',
       };
+      const expectedGetServices = [
+        'appConfiguration',
+        'http',
+        options.serviceName,
+        'router',
+      ];
       // When
-      result = gatewayController(options).connect(app, route);
+      result = gatewayController(options).register(app, route).connect();
       [[, service]] = app.set.mock.calls;
       // Then
       expect(result).toBe(router);
@@ -1203,24 +1212,27 @@ describe('controllers/utils:gateway', () => {
       };
       const app = {
         get: jest.fn((name) => services[name] || name),
-        set: jest.fn(),
+        set: jest.fn((name, fn) => {
+          services[name] = fn();
+        }),
         try: jest.fn(),
       };
       const route = '/my-gateway';
       let result = null;
       let service = null;
-      const expectedGetServices = [
-        'appConfiguration',
-        'http',
-        'router',
-      ];
       const options = {
         serviceName: 'myServiceGateway',
         configurationSetting: 'myConfigSetting',
         helperServiceName: null,
       };
+      const expectedGetServices = [
+        'appConfiguration',
+        'http',
+        options.serviceName,
+        'router',
+      ];
       // When
-      result = gatewayController(options).connect(app, route);
+      result = gatewayController(options).register(app, route).connect();
       [[, service]] = app.set.mock.calls;
       // Then
       expect(result).toBe(router);
@@ -1261,7 +1273,9 @@ describe('controllers/utils:gateway', () => {
       };
       const app = {
         get: jest.fn((name) => services[name] || name),
-        set: jest.fn(),
+        set: jest.fn((name, fn) => {
+          services[name] = fn();
+        }),
         try: jest.fn(),
       };
       const route = '/my-gateway';
@@ -1280,7 +1294,7 @@ describe('controllers/utils:gateway', () => {
         middlewares: middlewareGenerator,
       };
       // When
-      result = gatewayController(options).connect(app, route);
+      result = gatewayController(options).register(app, route).connect();
       // Then
       expect(result).toBe(router);
       expect(router.all).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### What does this PR do?

There was a problem with the gateway controller: one of its features is that it registers itself as a service so other resources can access it and get the API representation of its endpoints... the issue was that it was doing the registration on the mount step, because it was a controller.

Doing the registration at mount time meant that other controllers, middlewares and services that got executed when the application started couldn't get access to it.

The solution was to introduce a new type of "shorthand", the "controller providers":

```js
const something = provider((app, route) => {
  app.set('something', () => new Something(route));
  return controller(() => {
    cont ctrl = app.get('something');
    return app.get('router').get('/something', ctrl.doSomething());
  });
});
```

Basically a provider that returns a controller; that way, the `.set` can happen the moment `.mount` gets called, but the controller callback will still happen at the "mount step".

And there are "middleware providers" too:

```js
const something = provider((app) => {
  app.set('something', () => new Something());
  return middleware(() => app.get('something').middleware());
});
```

Now, the gateway controller became a controller provider that registers the service when `mount` is called :D.

Read the changes on the `README` for more information.

### How should it be tested manually?

```bash
npm test;
# or
yarn test;
```