### PR TITLE
11 - Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   },
   "lint-staged": {
-    "*.js": "eslint"
+    "*.js": ["eslint", "prettier --write"]
   },
   "scripts": {
     "hooks": "./utils/hooks/install",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@homer0/eslint-plugin": "^6.0.0",
     "@homer0/prettier-config": "^1.1.0",
     "@homer0/prettier-plugin-jsdoc": "^1.1.1",
-    "eslint": "^7.12.1",
+    "eslint": "^7.13.0",
     "jest": "^26.6.3",
     "jsdoc": "^3.6.6",
     "jsdoc-ts-utils": "^1.1.2",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -11,6 +11,14 @@ const statuses = require('statuses');
 const spdy = require('spdy');
 
 /**
+ * @typedef {import('../types').Express} Express
+ * @typedef {import('../types').SpdyServer} SpdyServer
+ * @typedef {import('../types').Server} Server
+ * @typedef {import('../types').JimpexStartCallback} JimpexStartCallback
+ * @typedef {import('../types').JimpexOptions} JimpexOptions
+ */
+
+/**
  * @module core
  */
 
@@ -113,7 +121,7 @@ class Jimpex extends Jimple {
      * "patched"
      * version of Express that uses Spdy.
      *
-     * @type {SpdyServer}
+     * @type {?SpdyServer}
      * @access protected
      * @ignore
      */

--- a/src/controllers/common/configuration.js
+++ b/src/controllers/common/configuration.js
@@ -1,6 +1,7 @@
 const { controller } = require('../../utils/wrappers');
 
 /**
+ * @typedef {import('../../types').AppConfiguration} AppConfiguration
  * @typedef {import('../../services/http/responsesBuilder').ResponsesBuilder}
  * ResponsesBuilder
  */

--- a/src/controllers/common/health.js
+++ b/src/controllers/common/health.js
@@ -1,6 +1,7 @@
 const { code: statuses } = require('statuses');
 const { controller } = require('../../utils/wrappers');
 /**
+ * @typedef {import('../../types').AppConfiguration} AppConfiguration
  * @typedef {import('../../services/http/responsesBuilder').ResponsesBuilder}
  * ResponsesBuilder
  */

--- a/src/controllers/common/statics.js
+++ b/src/controllers/common/statics.js
@@ -136,11 +136,11 @@ class StaticsController {
   /**
    * Defines all the needed routes to serve the files.
    *
-   * @param {Router}              router            To generate the routes.
+   * @param {ExpressRouter}       router            To generate the routes.
    * @param {ExpressMiddleware[]} [middlewares=[]]  A list of custom middlewares that will
    *                                                be added before the one that serves a
    *                                                file.
-   * @returns {Router}
+   * @returns {ExpressRouter}
    */
   addRoutes(router, middlewares = []) {
     const { methods } = this._options;
@@ -173,13 +173,13 @@ class StaticsController {
   /**
    * Generates a route for an specific file.
    *
-   * @param {Router}                router          To create the actual route.
+   * @param {ExpressRouter}         router          To create the actual route.
    * @param {string}                method          The HTTP method for the route.
    * @param {StaticsControllerFile} file            The file information.
    * @param {ExpressMiddleware}     fileMiddleware  The middleware that serves the file.
    * @param {ExpressMiddleware[]}   middlewares     A list of custom middlewares to add
    *                                                before the one that serves the file.
-   * @returns {Router}
+   * @returns {ExpressRouter}
    * @access protected
    * @ignore
    */

--- a/src/controllers/utils/gateway.js
+++ b/src/controllers/utils/gateway.js
@@ -461,12 +461,12 @@ class GatewayController {
   /**
    * Defines all the routes on a given router.
    *
-   * @param {Router}              router            The router where all the routes will
+   * @param {ExpressRouter}       router            The router where all the routes will
    *                                                be added.
    * @param {ExpressMiddleware[]} [middlewares=[]]  A list of custom middlewares that will
    *                                                be added before the one that makes the
    *                                                request.
-   * @returns {Router}
+   * @returns {ExpressRouter}
    */
   addRoutes(router, middlewares = []) {
     this._routes.forEach((route) =>
@@ -510,14 +510,14 @@ class GatewayController {
   /**
    * Adds a route on a given router.
    *
-   * @param {Router}            router              The router where the route will be
+   * @param {ExpressRouter}     router              The router where the route will be
    *                                                added.
    * @param {string}            method              The HTTP method for the route.
    * @param {string}            route               The path for the route.
    * @param {ExpressMiddleware} endpointMiddleware  The middleware that makes the request.
    * @param {Array}             middlewares         Extra middlewares to add before the
    *                                                main one.
-   * @returns {Router}
+   * @returns {ExpressRouter}
    * @access protected
    * @ignore
    */

--- a/src/middlewares/common/errorHandler.js
+++ b/src/middlewares/common/errorHandler.js
@@ -3,6 +3,7 @@ const { code: statuses } = require('statuses');
 const { middlewareCreator } = require('../../utils/wrappers');
 
 /**
+ * @typedef {import('../../types').Logger} Logger
  * @typedef {import('../../services/http/responsesBuilder').ResponsesBuilder}
  * ResponsesBuilder
  */

--- a/src/middlewares/common/forceHTTPS.js
+++ b/src/middlewares/common/forceHTTPS.js
@@ -1,4 +1,5 @@
 const { middlewareCreator } = require('../../utils/wrappers');
+
 /**
  * @typedef {Object} ForceHTTPSMiddlewareOptions
  * @property {RegExp[]} ignoredRoutes  A list of regular expressions to match routes that

--- a/src/middlewares/html/fastHTML.js
+++ b/src/middlewares/html/fastHTML.js
@@ -5,6 +5,7 @@ const { middlewareCreator } = require('../../utils/wrappers');
 const { createRouteExpression, removeSlashes } = require('../../utils/functions');
 
 /**
+ * @typedef {import('../../types').EventsHub} EventsHub
  * @typedef {import('../../services/common/sendFile').SendFile} SendFile
  * @typedef {import('../../services/html/htmlGenerator').HTMLGenerator} HTMLGenerator
  */

--- a/src/services/common/sendFile.js
+++ b/src/services/common/sendFile.js
@@ -1,6 +1,10 @@
 const { provider } = require('../../utils/wrappers');
 
 /**
+ * @typedef {import('../../types').PathUtils} PathUtils
+ */
+
+/**
  * @callback SendFile
  * @param {ExpressResponse} res           Necessary to write the file.
  * @param {string}          filepath      The path to the file relative to where the app

--- a/src/services/frontend/frontendFs.js
+++ b/src/services/frontend/frontendFs.js
@@ -1,6 +1,10 @@
 const fs = require('fs-extra');
 const { provider } = require('../../utils/wrappers');
 /**
+ * @typedef {import('../../types').PathUtils} PathUtils
+ */
+
+/**
  * This service allows the app to easily read static files. The idea behind centralizing
  * this functionalities into a service is that is pretty common to have bundling tools to
  * generate the frontend, and on that process files can have different paths or not even

--- a/src/services/html/htmlGenerator.js
+++ b/src/services/html/htmlGenerator.js
@@ -3,6 +3,8 @@ const { deferred } = require('wootils/shared');
 const { eventNames } = require('../../constants');
 const { providerCreator } = require('../../utils/wrappers');
 /**
+ * @typedef {import('../../types').AppConfiguration} AppConfiguration
+ * @typedef {import('../../types').Logger} Logger
  * @typedef {import('../frontend/frontendFs').FrontendFs} FrontendFs
  */
 

--- a/src/services/http/apiClient.js
+++ b/src/services/http/apiClient.js
@@ -3,6 +3,8 @@ const APIClientBase = require('wootils/shared/apiClient');
 const { providerCreator } = require('../../utils/wrappers');
 
 /**
+ * @typedef {import('../../types').APIClientBase} APIClientBase
+ * @typedef {import('../../types').APIClientEndpoints} APIClientEndpoints
  * @typedef {import('./http').HTTP} HTTP
  * @typedef {import('../common/httpError').HTTPError} HTTPError
  */

--- a/src/services/http/http.js
+++ b/src/services/http/http.js
@@ -1,6 +1,12 @@
 const fetch = require('node-fetch');
 const urijs = require('urijs');
 const { provider } = require('../../utils/wrappers');
+
+/**
+ * @typedef {import('../../types').Logger}  Logger
+ * @typedef {import('node-fetch').Response} Response
+ */
+
 /**
  * @typedef {Object} HTTPFetchOptions
  * @property {?string}                  method   The request method.
@@ -11,10 +17,6 @@ const { provider } = require('../../utils/wrappers');
  *                                               extra infromation (like headers and the
  *                                               IP).
  * @parent module:services
- */
-
-/**
- * @typedef {import('node-fetch').Response} Response
  */
 
 /**

--- a/src/services/http/responsesBuilder.js
+++ b/src/services/http/responsesBuilder.js
@@ -1,5 +1,10 @@
 const { code: statuses } = require('statuses');
 const { provider } = require('../../utils/wrappers');
+
+/**
+ * @typedef {import('../../types').AppConfiguration} AppConfiguration
+ */
+
 /**
  * It allows customization of a post message HTML template.
  *

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -1,367 +1,41 @@
 /**
- * @external Jimple
- * @see https://yarnpkg.com/en/package/jimple
+ * @typedef {import('./types').ExpressMiddleware} ExpressMiddleware
+ * @typedef {import('./types').ExpressRequest} ExpressRequest
+ * @typedef {import('./types').ExpressResponse} ExpressResponse
+ * @typedef {import('./types').ExpressNext} ExpressNext
+ * @typedef {import('./types').ExpressRouter} ExpressRouter
  */
 
 /**
- * @typedef {import('wootils/esm/node/appConfiguration').AppConfiguration}
- * AppConfiguration
- * @external AppConfiguration
- * @see https://homer0.github.io/wootils/module-node_appConfiguration.AppConfiguration.html
+ * @typedef {import('./types').Provider}  Provider
+ * @typedef {import('./types').Providers} Providers
  */
 
 /**
- * @typedef {import('wootils/esm/shared/apiClient').default} APIClientBase
- * @external APIClientBase
- * @see https://homer0.github.io/wootils/module-shared_apiClient.APIClient.html
- */
-
-/**
- * @typedef {import('wootils/esm/shared/apiClient').APIClientEndpoints} APIClientEndpoints
- * @external APIClientEndpoints
- * @see https://homer0.github.io/wootils/module-shared_apiClient.html#.APIClientEndpoints
- */
-
-/**
- * @typedef {import('wootils/esm/node/pathUtils').PathUtils} PathUtils
- * @external PathUtils
- * @see https://homer0.github.io/wootils/module-node_pathUtils.PathUtils.html
- */
-
-/**
- * @typedef {import('wootils/esm/node/logger').Logger} Logger
- * @external Logger
- * @see https://homer0.github.io/wootils/module-node_logger.Logger.html
- */
-
-/**
- * @typedef {import('wootils/esm/node/environmentUtils').EnvironmentUtils}
- * EnvironmentUtils
- * @external EnvironmentUtils
- * @see https://homer0.github.io/wootils/module-node_environmentUtils.EnvironmentUtils.html
- */
-
-/**
- * @typedef {import('wootils/esm/node/errorHandler').ErrorHandler} ErrorHandler
- * @external ErrorHandler
- * @see https://homer0.github.io/wootils/module-node_errorHandler.html
- */
-
-/**
- * @typedef {import('wootils/esm/shared/eventsHub').default} EventsHub
- * @external EventsHub
- * @see https://homer0.github.io/wootils/module-shared_eventsHub.html
- */
-
-/**
- * @typedef {import('wootils/esm/node/rootRequire').RootRequireFn} RootRequire
- * @external RootRequire
- * @see https://homer0.github.io/wootils/module-node_rootRequire.html#.RootRequireFn
- */
-
-/**
- * @typedef {import('express').Express} Express
- * @external Express
- * @see https://expressjs.com/en/4x/api.html
- */
-
-/**
- * @typedef {import('http').Server} HTTPServer
- * @external HTTPServer
- * @see https://nodejs.org/docs/latest-v10.x/api/http.html#http_class_http_server
- */
-
-/**
- * @typedef {import('spdy').ServerOptions} SpdyOptions
- * @external SpdyOptions
- * @see https://github.com/spdy-http2/node-spdy#options
- */
-
-/**
- * @typedef {import('spdy').Server} SpdyServer
- * @external SpdyServer
- * @see https://github.com/spdy-http2/node-spdy
- */
-
-/**
- * @typedef {HTTPServer | SpdyServer} Server
- */
-
-/**
- * @typedef {import('express').RequestHandler} RequestHandler
- * @typedef {import('express').ErrorRequestHandler} ErrorRequestHandler
- */
-
-/**
- * @typedef {RequestHandler | ErrorRequestHandler} ExpressMiddleware
- * @external ExpressMiddleware
- * @see http://expressjs.com/en/guide/using-middleware.html
- */
-
-/**
- * @typedef {import('express').Request} ExpressRequest
- * @external ExpressRequest
- * @see https://expressjs.com/en/4x/api.html#req
- */
-
-/**
- * @typedef {import('express').Response} ExpressResponse
- * @external ExpressResponse
- * @see https://expressjs.com/en/4x/api.html#res
- */
-
-/**
- * @typedef {import('express').Router} Router
- * @external Router
- * @see https://expressjs.com/en/4x/api.html#router
- */
-
-/**
- * @typedef {import('express').NextFunction} ExpressNext
- * @external ExpressNext
- * @see https://expressjs.com/en/guide/writing-middleware.html
- */
-
-/**
- * @typedef {import('wootils/esm/shared/jimpleFns').Provider} Provider
- * @external Provider
- * @see https://homer0.github.io/wootils/module-shared_jimpleFns.html#.Provider
- */
-
-/**
- * @typedef {import('wootils/esm/shared/jimpleFns').Providers} Providers
- * @external Providers
- * @see https://homer0.github.io/wootils/module-shared_jimpleFns.html#.Providers
- */
-
-/**
- * @typedef {import('wootils/esm/shared/jimpleFns').ProviderCreator<O>} ProviderCreator<O>
+ * @typedef {import('./types').ProviderCreator<O>} ProviderCreator<O>
  * @template O
- * @external ProviderCreator
- * @see https://homer0.github.io/wootils/module-shared_jimpleFns.html#~providerCreator
- */
-
-/* eslint-disable jsdoc/valid-types */
-/**
- * @typedef {import('./services/common/httpError')['HTTPError']} ClassHTTPError
- * @typedef {import('./services/common/appError')['AppError']} ClassAppError
- */
-/* eslint-enable jsdoc/valid-types */
-
-/**
- * @callback JimpexStartCallback
- * @param {AppConfiguration} appConfiguration  The service that handles the application
- *                                             configuration.
  */
 
 /**
- * @typedef {Object} JimpexConfigurationOptions
- * @property {?Object} default                       The app default configuration.
- *                                                   Default `null`.
- * @property {string}  name                          The name of the app, used for the
- *                                                   configuration files. Default `'app'`.
- * @property {string}  path                          The path to the configuration files
- *                                                   directory,
- *                                                   relative to the project root
- *                                                   directory. Default `'config/'`.
- * @property {boolean} hasFolder                     Whether the configurations are inside
- *                                                   a sub directory or not. If `true`, a
- *                                                   configuration path would be
- *                                                   `config/[app-name]/[file]`.
- *                                                   Default `true`.
- * @property {string}  environmentVariable           The name of the environment variable
- *                                                   that will be used to set the active
- *                                                   configuration.
- *                                                   Default `'CONFIG'`.
- * @property {boolean} loadFromEnvironment           Whether or not to check for the
- *                                                   environment variable and load a
- *                                                   configuration based on its value.
- *                                                   Default `true`.
- * @property {boolean} loadVersionFromConfiguration  If `true`, the app `version` will be
- *                                                   taken from the loaded configuration,
- *                                                   otherwise, when a configuration is
- *                                                   loaded, the app will copy the version
- *                                                   it has into the configuration.
- *                                                   Default `true`.
- * @property {string}  filenameFormat                The name format the configuration
- *                                                   files have.
- *                                                   Default:
- *
- *
- *                                                   `[app-name].[configuration-name].config.js`.
+ * @typedef {import('./types').Controller} Controller
+ * @typedef {import('./types').ControllerProvider} ControllerProvider
  */
 
 /**
- * @typedef {Object} JimpexStaticsOptions
- * @property {boolean} enabled  Whether or not to include the middleware for static files.
- *                              Default `true`.
- * @property {boolean} onHome   If `true`, the path to the statics folder will be relative
- *                              to the project root directory, otherwise, it will be
- *                              relative to the directory where the app executable file is
- *                              located. Default `false`.
- * @property {string}  route    The name of both the route and the folder, relative to
- *                              whatever you defined with the `onHome` option. Default
- *                              `'static'`.
- * @property {string}  folder   By default, the folder will be the same as the `route`,
- *                              but you can use this option to define a relative path that
- *                              won't affect the route. Default `''`.
+ * @typedef {import('./types').ControllerCreator<O>} ControllerCreator<O>
+ * @template O
  */
 
 /**
- * @typedef {Object} JimpexExpressOptions
- * @property {boolean} trustProxy         Whether or not to enable the `trust proxy`
- *                                        option.
- *                                        Default `true`.
- * @property {boolean} disableXPoweredBy  Whether or not to remove the `x-powered-by`
- *                                        header.
- *                                        Default `true`.
- * @property {boolean} compression        Whether or not to add the `compression`
- *                                        middleware.
- *                                        Default `true`.
- * @property {boolean} bodyParser         Whether or not to add the `body-parser`
- *                                        middleware.
- *                                        Default `true`.
- * @property {boolean} multer             Whether or not to add the `multer` middleware.
- *                                        Default `true`.
+ * @typedef {import('./types').Middleware} Middleware
+ * @typedef {import('./types').MiddlewareProvider} MiddlewareProvider
  */
 
 /**
- * @typedef {Object} JimpexDefaultServicesOptions
- * @property {boolean} common  Whether or not to register all the `common` service
- *                             providers.
- *                             Default `true`.
- * @property {boolean} http    Whether or not to register all the `http` service
- *                             providers.
- *                             Default `true`.
- * @property {boolean} utils   Whether or not to register all the `utils` service
- *                             providers.
- *                             Default `true`.
- */
-
-/**
- * @typedef {Object} JimpexOptions
- * @property {string} version
- * The app version. To be used on the configuration. Default `'0.0.0'`.
- * @property {string} filesizeLimit
- * The size limit for the requests payload. Default `'15MB'`.
- * @property {boolean} boot
- * Whether or not to automatically call the `boot` method after initialization.
- * Default `true`.
- * @property {boolean} proxy
- * Whether or not to enable the proxy mode, so all providers, controllers and middlewares
- * will receive a proxied reference of the container, in which they can set and get
- * resources using dot notation.
- * @property {JimpexConfigurationOptions} configuration
- * The options for the app configuration service.
- * @property {JimpexStaticsOptions} statics
- * The options for the app static `middleware`.
- * @property {JimpexExpressOptions} express
- * The options for the Express app.
- * @property {JimpexDefaultServicesOptions} defaultServices
- * To tell the app which services should be registered when instantiated.
+ * @typedef {import('./types').MiddlewareCreator<O>} MiddlewareCreator<O>
+ * @template O
  */
 
 /**
  * @typedef {import('./app').Jimpex} Jimpex
- */
-
-/**
- * An object that when mounted on Jimpex will take care of handling a list of specific
- * routes. The method Jimpex uses to mount a controller is {@link Jimpex#mount}.
- *
- * @typedef {Object} Controller
- * @property {ControllerConnectFn} connect     The function Jimpex calls when mounting the
- *                                             controller.
- * @property {boolean}             controller  A flag set to `true` to identify the
- *                                             resource as a routes controller.
- */
-
-/**
- * @callback ControllerProviderRegisterFn
- * @param {Jimpex} app    The instance of the application container.
- * @param {string} route  The route where the controller will be mounted.
- * @returns {Controller}
- */
-
-/**
- * This is a special kind of controller that not only registers routes but also adds
- * resources to the container, and to avoid doing it during the mount process, it
- * registers the resources first and then returns the actuall controller.
- *
- * @typedef {Object} ControllerProvider
- * @property {ControllerProviderRegisterFn} register  The function Jimpex calls when
- *                                                    registering the provider and the one
- *                                                    that has to generate the controller.
- */
-
-/**
- * The function called by the application container in order to mount a routes controller.
- *
- * @callback ControllerConnectFn
- * @param {Jimpex} app    The instance of the application container.
- * @param {string} route  The route where the controller will be mounted.
- * @returns {Router} The controller router.
- */
-
-/**
- * A function called in order to generate a {@link Controller}. They usually have
- * different options that will be sent to the controller creation.
- *
- * @callback ControllerCreatorFn
- * @returns {ControllerConnectFn}
- */
-
-/**
- * A special kind of {@link Controller} that can be used with {@link Jimpex#mount} as a
- * regular controller, or it can be called as a function with custom parameters in order
- * to obtain a "configured {@link Controller}".
- *
- * @callback ControllerCreator
- * @param {Partial<O>} [options={}]  The options to create the controller.
- * @returns {Controller | ControllerProvider}
- * @template O
- */
-
-/**
- * An object that when mounted on Jimpex add an {@link ExpressMiddleware} to the app. The
- * method Jimpex uses to mount a middleware is {@link Jimpex#use}.
- *
- * @typedef {Object} Middleware
- * @property {MiddlewareConnectFn} connect     The function Jimpex calls when mounting the
- *                                             middleware.
- * @property {boolean}             middleware  A flag set to `true` to identify the
- *                                             resource as a middleware.
- */
-
-/**
- * The function called by the application container in order to use a middleware.
- *
- * @callback MiddlewareConnectFn
- * @param {Jimpex} app  The instance of the application container.
- * @returns {?ExpressMiddleware} A middleware for Express to use. It can also return
- *                               `null` in case there's a reason for the middleware not to
- *                               be active.
- */
-
-/**
- * A function called in order to generate a {@link Middleware}. They usually have
- * different options that will be sent to the middleware creation.
- *
- * @callback MiddlewareCreatorFn
- * @returns {MiddlewareConnectFn}
- */
-
-/**
- * A special kind of {@link Middleware} that can be used with {@link Jimpex#use} as a
- * regular middleware, or it can be called as a function with custom parameters in order
- * to obtain a "configured {@link Middleware}".
- *
- * @callback MiddlewareCreator
- * @param {Partial<O>} [options={}]  The options to create the controller.
- * @returns {Middleware}
- * @template O
- */
-
-/**
- * @typedef {Middleware | ExpressMiddleware} MiddlewareLike
  */

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,377 @@
+/**
+ * @typedef {import('jimple')} Jimple
+ * @external Jimple
+ * @see https://yarnpkg.com/en/package/jimple
+ */
+
+// ==============================================
+// Externals - Wootils
+// ==============================================
+
+/**
+ * @typedef {import('wootils/esm/node/appConfiguration').AppConfiguration}
+ * AppConfiguration
+ * @external AppConfiguration
+ * @see https://homer0.github.io/wootils/module-node_appConfiguration.AppConfiguration.html
+ */
+
+/**
+ * @typedef {import('wootils/esm/shared/apiClient').default} APIClientBase
+ * @external APIClientBase
+ * @see https://homer0.github.io/wootils/module-shared_apiClient.APIClient.html
+ */
+
+/**
+ * @typedef {import('wootils/esm/shared/apiClient').APIClientEndpoints} APIClientEndpoints
+ * @external APIClientEndpoints
+ * @see https://homer0.github.io/wootils/module-shared_apiClient.html#.APIClientEndpoints
+ */
+
+/**
+ * @typedef {import('wootils/esm/node/pathUtils').PathUtils} PathUtils
+ * @external PathUtils
+ * @see https://homer0.github.io/wootils/module-node_pathUtils.PathUtils.html
+ */
+
+/**
+ * @typedef {import('wootils/esm/node/logger').Logger} Logger
+ * @external Logger
+ * @see https://homer0.github.io/wootils/module-node_logger.Logger.html
+ */
+
+/**
+ * @typedef {import('wootils/esm/node/environmentUtils').EnvironmentUtils}
+ * EnvironmentUtils
+ * @external EnvironmentUtils
+ * @see https://homer0.github.io/wootils/module-node_environmentUtils.EnvironmentUtils.html
+ */
+
+/**
+ * @typedef {import('wootils/esm/shared/eventsHub').default} EventsHub
+ * @external EventsHub
+ * @see https://homer0.github.io/wootils/module-shared_eventsHub.html
+ */
+
+/**
+ * @typedef {import('wootils/esm/shared/jimpleFns').Provider} Provider
+ * @external Provider
+ * @see https://homer0.github.io/wootils/module-shared_jimpleFns.html#.Provider
+ */
+
+/**
+ * @typedef {import('wootils/esm/shared/jimpleFns').Providers} Providers
+ * @external Providers
+ * @see https://homer0.github.io/wootils/module-shared_jimpleFns.html#.Providers
+ */
+
+/**
+ * @typedef {import('wootils/esm/shared/jimpleFns').ProviderCreator<O>} ProviderCreator<O>
+ * @template O
+ * @external ProviderCreator
+ * @see https://homer0.github.io/wootils/module-shared_jimpleFns.html#~providerCreator
+ */
+
+// ==============================================
+// Externals - Express/Server
+// ==============================================
+
+/**
+ * @typedef {import('express').Express} Express
+ * @external Express
+ * @see https://expressjs.com/en/4x/api.html
+ */
+
+/**
+ * @typedef {import('http').Server} HTTPServer
+ * @external HTTPServer
+ * @see https://nodejs.org/docs/latest-v10.x/api/http.html#http_class_http_server
+ */
+
+/**
+ * @typedef {import('spdy').Server} SpdyServer
+ * @external SpdyServer
+ * @see https://github.com/spdy-http2/node-spdy
+ */
+/**
+ * @typedef {import('spdy').ServerOptions} SpdyOptions
+ * @external SpdyOptions
+ * @see https://github.com/spdy-http2/node-spdy#options
+ */
+
+/**
+ * @typedef {HTTPServer | SpdyServer} Server
+ */
+
+/**
+ * @typedef {import('express').RequestHandler} RequestHandler
+ * @typedef {import('express').ErrorRequestHandler} ErrorRequestHandler
+ */
+
+/**
+ * @typedef {RequestHandler | ErrorRequestHandler} ExpressMiddleware
+ * @external ExpressMiddleware
+ * @see http://expressjs.com/en/guide/using-middleware.html
+ */
+
+/**
+ * @typedef {import('express').Request} ExpressRequest
+ * @external ExpressRequest
+ * @see https://expressjs.com/en/4x/api.html#req
+ */
+
+/**
+ * @typedef {import('express').Response} ExpressResponse
+ * @external ExpressResponse
+ * @see https://expressjs.com/en/4x/api.html#res
+ */
+/**
+ * @typedef {import('express').NextFunction} ExpressNext
+ * @external ExpressNext
+ * @see https://expressjs.com/en/guide/writing-middleware.html
+ */
+
+/**
+ * @typedef {import('express').Router} ExpressRouter
+ * @external Router
+ * @see https://expressjs.com/en/4x/api.html#router
+ */
+
+// ==============================================
+// Jimpex - Global classes
+// ==============================================
+
+/* eslint-disable jsdoc/valid-types */
+/**
+ * @typedef {import('./services/common/httpError')['HTTPError']} ClassHTTPError
+ * @typedef {import('./services/common/appError')['AppError']} ClassAppError
+ */
+/* eslint-enable jsdoc/valid-types */
+
+/**
+ * @typedef {import('./app').Jimpex} Jimpex
+ */
+
+// ==============================================
+// Jimpex
+// ==============================================
+
+/**
+ * @callback JimpexStartCallback
+ * @param {AppConfiguration} appConfiguration  The service that handles the application
+ *                                             configuration.
+ */
+
+/**
+ * @typedef {Object} JimpexConfigurationOptions
+ * @property {?Object} default                       The app default configuration.
+ *                                                   Default `null`.
+ * @property {string}  name                          The name of the app, used for the
+ *                                                   configuration files. Default `'app'`.
+ * @property {string}  path                          The path to the configuration files
+ *                                                   directory,
+ *                                                   relative to the project root
+ *                                                   directory. Default `'config/'`.
+ * @property {boolean} hasFolder                     Whether the configurations are inside
+ *                                                   a sub directory or not. If `true`, a
+ *                                                   configuration path would be
+ *                                                   `config/[app-name]/[file]`.
+ *                                                   Default `true`.
+ * @property {string}  environmentVariable           The name of the environment variable
+ *                                                   that will be used to set the active
+ *                                                   configuration.
+ *                                                   Default `'CONFIG'`.
+ * @property {boolean} loadFromEnvironment           Whether or not to check for the
+ *                                                   environment variable and load a
+ *                                                   configuration based on its value.
+ *                                                   Default `true`.
+ * @property {boolean} loadVersionFromConfiguration  If `true`, the app `version` will be
+ *                                                   taken from the loaded configuration,
+ *                                                   otherwise, when a configuration is
+ *                                                   loaded, the app will copy the version
+ *                                                   it has into the configuration.
+ *                                                   Default `true`.
+ * @property {string}  filenameFormat                The name format the configuration
+ *                                                   files have.
+ *                                                   Default:
+ *
+ *
+ *                                                   `[app-name].[configuration-name].config.js`.
+ */
+
+/**
+ * @typedef {Object} JimpexStaticsOptions
+ * @property {boolean} enabled  Whether or not to include the middleware for static files.
+ *                              Default `true`.
+ * @property {boolean} onHome   If `true`, the path to the statics folder will be relative
+ *                              to the project root directory, otherwise, it will be
+ *                              relative to the directory where the app executable file is
+ *                              located. Default `false`.
+ * @property {string}  route    The name of both the route and the folder, relative to
+ *                              whatever you defined with the `onHome` option. Default
+ *                              `'static'`.
+ * @property {string}  folder   By default, the folder will be the same as the `route`,
+ *                              but you can use this option to define a relative path that
+ *                              won't affect the route. Default `''`.
+ */
+
+/**
+ * @typedef {Object} JimpexExpressOptions
+ * @property {boolean} trustProxy         Whether or not to enable the `trust proxy`
+ *                                        option.
+ *                                        Default `true`.
+ * @property {boolean} disableXPoweredBy  Whether or not to remove the `x-powered-by`
+ *                                        header.
+ *                                        Default `true`.
+ * @property {boolean} compression        Whether or not to add the `compression`
+ *                                        middleware.
+ *                                        Default `true`.
+ * @property {boolean} bodyParser         Whether or not to add the `body-parser`
+ *                                        middleware.
+ *                                        Default `true`.
+ * @property {boolean} multer             Whether or not to add the `multer` middleware.
+ *                                        Default `true`.
+ */
+
+/**
+ * @typedef {Object} JimpexDefaultServicesOptions
+ * @property {boolean} common  Whether or not to register all the `common` service
+ *                             providers.
+ *                             Default `true`.
+ * @property {boolean} http    Whether or not to register all the `http` service
+ *                             providers.
+ *                             Default `true`.
+ * @property {boolean} utils   Whether or not to register all the `utils` service
+ *                             providers.
+ *                             Default `true`.
+ */
+
+/**
+ * @typedef {Object} JimpexOptions
+ * @property {string} version
+ * The app version. To be used on the configuration. Default `'0.0.0'`.
+ * @property {string} filesizeLimit
+ * The size limit for the requests payload. Default `'15MB'`.
+ * @property {boolean} boot
+ * Whether or not to automatically call the `boot` method after initialization.
+ * Default `true`.
+ * @property {boolean} proxy
+ * Whether or not to enable the proxy mode, so all providers, controllers and middlewares
+ * will receive a proxied reference of the container, in which they can set and get
+ * resources using dot notation.
+ * @property {JimpexConfigurationOptions} configuration
+ * The options for the app configuration service.
+ * @property {JimpexStaticsOptions} statics
+ * The options for the app static `middleware`.
+ * @property {JimpexExpressOptions} express
+ * The options for the Express app.
+ * @property {JimpexDefaultServicesOptions} defaultServices
+ * To tell the app which services should be registered when instantiated.
+ */
+
+// ==============================================
+// Jimpex - Custom wrappers
+// ==============================================
+
+/**
+ * An object that when mounted on Jimpex will take care of handling a list of specific
+ * routes. The method Jimpex uses to mount a controller is {@link Jimpex#mount}.
+ *
+ * @typedef {Object} Controller
+ * @property {ControllerConnectFn} connect     The function Jimpex calls when mounting the
+ *                                             controller.
+ * @property {boolean}             controller  A flag set to `true` to identify the
+ *                                             resource as a routes controller.
+ */
+
+/**
+ * @callback ControllerProviderRegisterFn
+ * @param {Jimpex} app    The instance of the application container.
+ * @param {string} route  The route where the controller will be mounted.
+ * @returns {Controller}
+ */
+
+/**
+ * This is a special kind of controller that not only registers routes but also adds
+ * resources to the container, and to avoid doing it during the mount process, it
+ * registers the resources first and then returns the actuall controller.
+ *
+ * @typedef {Object} ControllerProvider
+ * @property {ControllerProviderRegisterFn} register  The function Jimpex calls when
+ *                                                    registering the provider and the one
+ *                                                    that has to generate the controller.
+ */
+
+/**
+ * The function called by the application container in order to mount a routes controller.
+ *
+ * @callback ControllerConnectFn
+ * @param {Jimpex} app    The instance of the application container.
+ * @param {string} route  The route where the controller will be mounted.
+ * @returns {Router} The controller router.
+ */
+
+/**
+ * A function called in order to generate a {@link Controller}. They usually have
+ * different options that will be sent to the controller creation.
+ *
+ * @callback ControllerCreatorFn
+ * @returns {ControllerConnectFn}
+ */
+
+/**
+ * A special kind of {@link Controller} that can be used with {@link Jimpex#mount} as a
+ * regular controller, or it can be called as a function with custom parameters in order
+ * to obtain a "configured {@link Controller}".
+ *
+ * @callback ControllerCreator
+ * @param {Partial<O>} [options={}]  The options to create the controller.
+ * @returns {Controller | ControllerProvider}
+ * @template O
+ */
+
+/**
+ * An object that when mounted on Jimpex add an {@link ExpressMiddleware} to the app. The
+ * method Jimpex uses to mount a middleware is {@link Jimpex#use}.
+ *
+ * @typedef {Object} Middleware
+ * @property {MiddlewareConnectFn} connect     The function Jimpex calls when mounting the
+ *                                             middleware.
+ * @property {boolean}             middleware  A flag set to `true` to identify the
+ *                                             resource as a middleware.
+ */
+
+/**
+ * The function called by the application container in order to use a middleware.
+ *
+ * @callback MiddlewareConnectFn
+ * @param {Jimpex} app  The instance of the application container.
+ * @returns {?ExpressMiddleware} A middleware for Express to use. It can also return
+ *                               `null` in case there's a reason for the middleware not to
+ *                               be active.
+ */
+
+/**
+ * A function called in order to generate a {@link Middleware}. They usually have
+ * different options that will be sent to the middleware creation.
+ *
+ * @callback MiddlewareCreatorFn
+ * @returns {MiddlewareConnectFn}
+ */
+
+/**
+ * A special kind of {@link Middleware} that can be used with {@link Jimpex#use} as a
+ * regular middleware, or it can be called as a function with custom parameters in order
+ * to obtain a "configured {@link Middleware}".
+ *
+ * @callback MiddlewareCreator
+ * @param {Partial<O>} [options={}]  The options to create the controller.
+ * @returns {Middleware}
+ * @template O
+ */
+
+/**
+ * @typedef {Middleware | ExpressMiddleware} MiddlewareLike
+ */
+
+// eslint-disable-next-line
+export {};

--- a/src/utils/wrappers.js
+++ b/src/utils/wrappers.js
@@ -7,6 +7,13 @@ const {
 } = require('wootils/shared/jimpleFns');
 
 /**
+ * @typedef {import('../types').ControllerConnectFn} ControllerConnectFn
+ * @typedef {import('../types').ControllerCreatorFn} ControllerCreatorFn
+ * @typedef {import('../types').MiddlewareConnectFn} MiddlewareConnectFn
+ * @typedef {import('../types').MiddlewareCreatorFn} MiddlewareCreatorFn
+ */
+
+/**
  * @module wrappers
  */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,7 +1277,7 @@ concat-stream@^1.5.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-confusing-browser-globals@^1.0.9:
+confusing-browser-globals@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
   integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
@@ -1670,12 +1670,12 @@ escodegen@^1.14.1:
     source-map "~0.6.1"
 
 eslint-config-airbnb-base@^14.2.0:
-  version "14.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz#fe89c24b3f9dc8008c9c0d0d88c28f95ed65e9c4"
-  integrity sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz#8a2eb38455dc5a312550193b319cdaeef042cd1e"
+  integrity sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==
   dependencies:
-    confusing-browser-globals "^1.0.9"
-    object.assign "^4.1.0"
+    confusing-browser-globals "^1.0.10"
+    object.assign "^4.1.2"
     object.entries "^1.1.2"
 
 eslint-config-prettier@^6.15.0:
@@ -1783,10 +1783,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.12.1:
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.12.1.tgz#bd9a81fa67a6cfd51656cdb88812ce49ccec5801"
-  integrity sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==
+eslint@^7.12.1, eslint@^7.13.0:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.13.0.tgz#7f180126c0dcdef327bfb54b211d7802decc08da"
+  integrity sha512-uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@eslint/eslintrc" "^0.2.1"
@@ -3876,7 +3876,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.1.0, object.assign@^4.1.1:
+object.assign@^4.1.1, object.assign@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
   integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==


### PR DESCRIPTION
### What does this PR do?

Removes most of the types from the `typedef.js`; quote from the first commit:

> The problem with the typedef.js file is that the IDE will automatically load it for
all files located on the same level or below; if a file is on a higher level, it
won't get the the typedef types. Also, types from a typedef file can't be imported,
as there's no actual JS code on the file, the editor won't allow type imports, and
if you add some code, it invalids its "typedef status" and its types are not longer
globals.
>
> The solution was to create a types.js, add an empty exports and import the types
from there; and for the couple of types that should be global, import them from
a "small typedef".

I also added the missing `lint-staged` script for Prettier.

### How should it be tested manually?

```bash
npm test;
# or
yarn
```