### PR TITLE
fix: use the right path to the types

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "node": ">=10.0.0"
   },
   "main": "./src/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./types/src/index.d.ts",
   "husky": {
     "hooks": {
       "pre-commit": "./utils/hooks/pre-commit",


### PR DESCRIPTION
### What does this PR do?

Follow up for #61 - The types are on `types/src/...`, not `types/...`.

### How should it be tested manually?

Install the package and try to use the types.