### PR TITLE
Fix class type

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",
   "dependencies": {
-    "wootils": "^4.3.1",
+    "wootils": "^4.3.2",
     "jimple": "^1.5.0",
     "express": "^4.17.1",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "node": ">=10.0.0"
   },
   "main": "./src/index.js",
-  "types": "./types/src/index.d.ts",
+  "types": "./types/index.d.ts",
   "husky": {
     "hooks": {
       "pre-commit": "./utils/hooks/pre-commit",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "allowJs": true,
     "emitDeclarationOnly": true,
-    "outDir": "types",
+    "outDir": "types/",
     "rootDir": "./",
     "target": "es6",
     "module": "commonjs"

--- a/utils/scripts/types
+++ b/utils/scripts/types
@@ -1,4 +1,6 @@
 #!/bin/bash -e
 
 tsc
-cp ./utils/types/index.d.ts.template ./types/src/app/index.d.ts
+mv ./types/src/* ./types
+rm -rf ./types/src
+cp ./utils/types/index.d.ts.template ./types/app/index.d.ts

--- a/utils/scripts/types
+++ b/utils/scripts/types
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 
 tsc
+cp ./utils/types/index.d.ts.template ./types/src/app/index.d.ts

--- a/utils/types/index.d.ts.template
+++ b/utils/types/index.d.ts.template
@@ -1,0 +1,417 @@
+/// <reference types="node" />
+import Jimple from 'jimple';
+export type Express = express.Express;
+export type SpdyServer = https.Server;
+export type Provider = {
+  register: import('wootils/esm/shared/jimpleFns').ProviderRegisterFn;
+};
+export type Controller = {
+  /**
+   * The function Jimpex calls when mounting the
+   * controller.
+   */
+  connect: import('../types').ControllerConnectFn;
+  /**
+   * A flag set to `true` to identify the
+   * resource as a routes controller.
+   */
+  controller: boolean;
+};
+export type ControllerProvider = {
+  /**
+   * The function Jimpex calls when
+   * registering the provider and the one
+   * that has to generate the controller.
+   */
+  register: import('../types').ControllerProviderRegisterFn;
+};
+export type MiddlewareLike =
+  | import('../types').Middleware
+  | express.RequestHandler<
+      import('express-serve-static-core').ParamsDictionary,
+      any,
+      any,
+      qs.ParsedQs,
+      Record<string, any>
+    >
+  | express.ErrorRequestHandler<
+      import('express-serve-static-core').ParamsDictionary,
+      any,
+      any,
+      qs.ParsedQs,
+      Record<string, any>
+    >;
+export type Server = import('http').Server | https.Server;
+export type JimpexStartCallback = (
+  appConfiguration: import('wootils/esm/node/appConfiguration').AppConfiguration,
+) => any;
+export type JimpexOptions = {
+  /**
+   * The app version. To be used on the configuration. Default `'0.0.0'`.
+   */
+  version: string;
+  /**
+   * The size limit for the requests payload. Default `'15MB'`.
+   */
+  filesizeLimit: string;
+  /**
+   * Whether or not to automatically call the `boot` method after initialization.
+   * Default `true`.
+   */
+  boot: boolean;
+  /**
+   * Whether or not to enable the proxy mode, so all providers, controllers and middlewares
+   * will receive a proxied reference of the container, in which they can set and get
+   * resources using dot notation.
+   */
+  proxy: boolean;
+  /**
+   * The options for the app configuration service.
+   */
+  configuration: import('../types').JimpexConfigurationOptions;
+  /**
+   * The options for the app static `middleware`.
+   */
+  statics: import('../types').JimpexStaticsOptions;
+  /**
+   * The options for the Express app.
+   */
+  express: import('../types').JimpexExpressOptions;
+  /**
+   * To tell the app which services should be registered when instantiated.
+   */
+  defaultServices: import('../types').JimpexDefaultServicesOptions;
+};
+/**
+ * Jimpex is a mix of Jimple, a Javascript port of Pimple dependency injection container,
+ * and Express, one of the most popular web frameworks for Node.
+ *
+ * @augments Jimple
+ * @parent module:core
+ * @todo Implement `helmet`.
+ */
+export class Jimpex extends Jimple {
+  /**
+   * @param {Partial<JimpexOptions>} [options={}]
+   * Preferences to customize the application.
+   * @param {?Object} [configuration=null]
+   * The default configuration for the `appConfiguration` service.
+   */
+  constructor(options?: Partial<JimpexOptions>, configuration?: any | null);
+  /**
+   * The application options.
+   *
+   * @type {JimpexOptions}
+   * @access protected
+   * @ignore
+   */
+  _options: JimpexOptions;
+  /**
+   * If the `proxy` option was set to `true`, this property will have a reference for a
+   * proxy of the container, in which resources can be registered and obtained using dot
+   * notation.
+   *
+   * @type {?Proxy<Jimpex>}
+   * @access protected
+   * @ignore
+   */
+  _proxy: ProxyConstructor | null;
+  /**
+   * The Express application Jimpex uses under the hood.
+   *
+   * @type {Express}
+   * @access protected
+   * @ignore
+   */
+  _express: Express;
+  /**
+   * When Jimpex is used with HTTP2 enabled, this property will be used to store the
+   * "patched"
+   * version of Express that uses Spdy.
+   *
+   * @type {?SpdyServer}
+   * @access protected
+   * @ignore
+   */
+  _spdy: SpdyServer | null;
+  /**
+   * When the application starts, this will be the instance of the server.
+   *
+   * @type {?Server}
+   * @access protected
+   * @ignore
+   */
+  _instance: Server | null;
+  /**
+   * A list of functions that return controllers and middlewares. When the application
+   * starts,
+   * the queue will be processed and those controllers and middlewares will be added to
+   * the server instance The reason they are not added directly like with a regular
+   * Express implementation is that services on Jimple use lazy loading, and adding
+   * middlewares and controllers as they come could cause errors if they depend on
+   * services that are not yet registered.
+   *
+   * @type {Function[]}
+   * @access protected
+   * @ignore
+   */
+  _mountQueue: Function[];
+  /**
+   * A list with all the top routes controlled by the application. Every time a
+   * controller is mounted, its route will be added here.
+   *
+   * @type {string[]}
+   * @access protected
+   * @ignore
+   */
+  _controlledRoutes: string[];
+  /**
+   * This is where the app would register all its specific services, middlewares and controllers.
+   */
+  boot(): void;
+  /**
+   * Disables the server TLS validation.
+   */
+  disableTLSValidation(): void;
+  /**
+   * This is an alias of `start`. The idea is for it to be used on serverless platforms,
+   * where you don't get to start your app, you just have export it.
+   *
+   * @param {?number}              [port=null]  In case the configuration doesn't
+   *                                            already have it,
+   *                                            this is the port where the application
+   *                                            will use to run. If this parameter is
+   *                                            used, the method will overwrite the
+   *                                            `port`
+   *                                            setting on the configuration service.
+   * @param {?JimpexStartCallback} [fn=null]    A callback function to be called when
+   *                                            the server starts.
+   * @returns {Server} The server instance.
+   */
+  listen(port?: number | null, fn?: JimpexStartCallback | null): Server;
+  /**
+   * Mounts a controller on a specific route.
+   *
+   * @param {string} route
+   * The route for the controller.
+   * @param {Controller | ControllerProvider} controller
+   * The route controller.
+   */
+  mount(route: string, controller: Controller | ControllerProvider): void;
+  /**
+   * Gets "safe" reference for the container that validates if the "proxy mode" is
+   * enabled, in order to provide the proxy or the actual instance.
+   *
+   * @returns {Jimpex}
+   */
+  ref(): Jimpex;
+  /**
+   * Registers a provider to extend the application.
+   *
+   * @param {Provider} provider  The provider to register.
+   */
+  register(provider: Provider): void;
+  /**
+   * Starts the app server.
+   *
+   * @param {?JimpexStartCallback} [fn=null]  A callback function to be called when the
+   *                                          server starts.
+   * @returns {Object} The server instance.
+   */
+  start(fn?: JimpexStartCallback | null): any;
+  _server: import('../types').Server;
+  /**
+   * Stops the server instance.
+   */
+  stop(): void;
+  /**
+   * Tries to access a resource on the container, but if is not present, it won't throw
+   * an error,
+   * it will just return `null`.
+   *
+   * @param {string} name  The name of the resource.
+   * @returns {*}
+   * @throws {Error} If there's an error other than the one generated when the
+   *                 resource doesn't exist.
+   */
+  try(name: string): any;
+  /**
+   * Adds a middleware.
+   *
+   * @param {MiddlewareLike} middleware  The middleware to use.
+   */
+  use(middleware: MiddlewareLike): void;
+  /**
+   * The Express app Jimpex uses under the hood.
+   *
+   * @type {Express}
+   */
+  get express(): express.Express;
+  /**
+   * The server instance that gets created when the app is started.
+   *
+   * @returns {?Server}
+   */
+  get instance(): import('../types').Server;
+  /**
+   * The app options.
+   *
+   * @type {JimpexOptions}
+   */
+  get options(): import('../types').JimpexOptions;
+  /**
+   * A list of all the top routes controlled by the app.
+   *
+   * @type {string[]}
+   */
+  get routes(): string[];
+  /**
+   * Helper method to add static folders to the app.
+   *
+   * @param {string}  route           The route for the static folder.
+   * @param {string}  [folder='']     The path to the folder. If not defined, it will
+   *                                  use the value from `route`.
+   * @param {boolean} [onHome=false]  If `true`, the path to the folder will be relative
+   *                                  to where the app is being executed
+   *                                  (`process.cwd()`), otherwise, it will be relative
+   *                                  to where the executable file is located.
+   * @access protected
+   * @ignore
+   */
+  _addStaticsFolder(route: string, folder?: string, onHome?: boolean): void;
+  /**
+   * Emits an app event with a reference to this class instance.
+   *
+   * @param {string} name  The name of the event on {@link JimpexEvents}.
+   * @param {...*}   args  Extra parameters for the listeners.
+   * @access protected
+   * @ignore
+   */
+  _emitEvent(name: string, ...args: any[]): void;
+  /**
+   * Validates the configuration and chooses the server the application needs to use: If
+   * HTTP2 is enabled, it will use Spdy; if HTTP is enabled but HTTP is not, it will use
+   * the native HTTPS server; otherwise, it will be just the Express instance.
+   *
+   * @returns {Server}
+   * @throws {Error} If HTTP2 is enabled but HTTPS is not.
+   * @throws {Error} If HTTPS is enabled but there's no `https.credentials` object.
+   * @throws {Error} If HTTPS is enabled and no creadentials are found.
+   * @access protected
+   * @ignore
+   */
+  _getServer(): Server;
+  /**
+   * This method is like a "lifecycle method", it gets executed on the constructor right
+   * before the "boot step". The idea is for the method to be a helper when application
+   * is defined by subclassing {@link Jimpex}: the application could register all
+   * important services here and the routes on boot, then, if the implementation needs
+   * to access or overwrite a something, it can send `boot: false`, access/register what
+   * it needs and then call `boot()`. That would be impossible for an application
+   * without overwriting the constructor and the boot functionality.
+   *
+   * @access protected
+   */
+  _init(): void;
+  /**
+   * It generates overwrites for the class options when they are created. This method is
+   * a helper for when the application is defined by subclassing {@link Jimpex}: It's
+   * highly probable that if the application needs to change the default options, it
+   * would want to do it right from the class, instead of having to do it on every
+   * implementation. A way to do it would be overwriting the constructor and calling
+   * `super` with the custom overwrites; this method exists so that won't be necessary:
+   * when creating the `options`, the constructor will merge the result of this method
+   * on top of the default ones.
+   *
+   * @returns {Partial<JimpexOptions>}
+   * @access protected
+   */
+  _initOptions(): Partial<JimpexOptions>;
+  /**
+   * Loads the contents of a dictionary of files that need to be used for HTTPS
+   * credentials.
+   *
+   * @param {boolean} onHome
+   * If this is `true`, the path of the files will be relative to the project root
+   * directory;
+   * otherwise, it will be relative to the directory where the application executable is
+   * located.
+   * @param {Object.<string, string>} credentialsInfo
+   * The dictionary where the keys are the type of credentials (`ca`,
+   * `cert` and/or `key`) and the values the paths to the files.
+   * @returns {Object.<string, string>}
+   * @access protected
+   * @ignore
+   */
+  _loadCredentials(
+    onHome: boolean,
+    credentialsInfo: {
+      [x: string]: string;
+    },
+  ): {
+    [x: string]: string;
+  };
+  /**
+   * Processes and mount all the resources on the `mountQueue`.
+   *
+   * @access protected
+   * @ignore
+   */
+  _mountResources(): void;
+  /**
+   * Sends a target object to a list of reducer events so they can modify or replace it.
+   * This method also sends a reference to this class instance as the last parameter of
+   * the event.
+   *
+   * @param {string} name    The name of the event on {@link JimpexEvents}.
+   * @param {*}      target  The targe object to reduce.
+   * @param {...*}   args    Extra parameters for the listeners.
+   * @returns {*} An object of the same type as the `target`.
+   * @access protected
+   * @ignore
+   */
+  _reduceWithEvent(name: string, target: any, ...args: any[]): any;
+  /**
+   * Creates the configuration service.
+   *
+   * @access protected
+   * @ignore
+   */
+  _setupConfiguration(): void;
+  /**
+   * Registers the _'core services'_.
+   *
+   * @access protected
+   * @ignore
+   */
+  _setupCoreServices(): void;
+  /**
+   * Based on the constructor received options, register or not the default services.
+   *
+   * @access protected
+   * @ignore
+   */
+  _setupDefaultServices(): void;
+  /**
+   * Creates and configure the Express instance.
+   *
+   * @access protected
+   * @ignore
+   */
+  _setupExpress(): void;
+}
+/**
+ * Creates a new instance of {@link Jimpex}.
+ *
+ * @param {Partial<JimpexOptions>} [options={}]
+ * Preferences to customize the application.
+ * @param {?Object} [configuration=null]
+ * The default configuration for the `appConfiguration` service.
+ * @returns {Jimpex}
+ */
+export function jimpex(
+  options?: Partial<JimpexOptions>,
+  configuration?: any | null,
+): Jimpex;
+import express = require('express');
+import https = require('https');

--- a/yarn.lock
+++ b/yarn.lock
@@ -539,16 +539,16 @@
     fastq "^1.6.0"
 
 "@octokit/auth-token@^2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.4.tgz#ee31c69b01d0378c12fd3ffe406030f3d94d3b56"
-  integrity sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
+  integrity sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==
   dependencies:
-    "@octokit/types" "^6.0.0"
+    "@octokit/types" "^6.0.3"
 
 "@octokit/core@^3.2.3":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.2.4.tgz#5791256057a962eca972e31818f02454897fd106"
-  integrity sha512-d9dTsqdePBqOn7aGkyRFe7pQpCXdibSJ5SFnrTr0axevObZrpz3qkWm7t/NjYv5a66z6vhfteriaq4FRz3e0Qg==
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.2.5.tgz#57becbd5fd789b0592b915840855f3a5f233d554"
+  integrity sha512-+DCtPykGnvXKWWQI0E1XD+CCeWSBhB6kwItXqfFmNBlIlhczuDPbg+P6BtLnVBaRJDAjv+1mrUJuRsFSjktopg==
   dependencies:
     "@octokit/auth-token" "^2.4.4"
     "@octokit/graphql" "^4.5.8"
@@ -558,21 +558,21 @@
     universal-user-agent "^6.0.0"
 
 "@octokit/endpoint@^6.0.1":
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.10.tgz#741ce1fa2f4fb77ce8ebe0c6eaf5ce63f565f8e8"
-  integrity sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.11.tgz#082adc2aebca6dcefa1fb383f5efb3ed081949d1"
+  integrity sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==
   dependencies:
-    "@octokit/types" "^6.0.0"
+    "@octokit/types" "^6.0.3"
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/graphql@^4.5.8":
-  version "4.5.8"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.8.tgz#d42373633c3015d0eafce64a8ce196be167fdd9b"
-  integrity sha512-WnCtNXWOrupfPJgXe+vSmprZJUr0VIu14G58PMlkWGj3cH+KLZEfKMmbUQ6C3Wwx6fdhzVW1CD5RTnBdUHxhhA==
+  version "4.5.9"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.9.tgz#2365831a1a88f4cb6fd4b0488edb6587d8243024"
+  integrity sha512-c+0yofIugUNqo+ktrLaBlWSbjSq/UF8ChAyxQzbD3X74k1vAuyLKdDJmPwVExUFSp6+U1FzWe+3OkeRsIqV0vg==
   dependencies:
     "@octokit/request" "^5.3.0"
-    "@octokit/types" "^6.0.0"
+    "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
 "@octokit/openapi-types@^3.2.0":
@@ -581,16 +581,16 @@
   integrity sha512-X7yW/fpzF3uTAE+LbPD3HEeeU+/49o0V4kNA/yv8jQ3BDpFayv/osTOhY1y1mLXljW2bOJcOCSGZo4jFKPJ6Vw==
 
 "@octokit/plugin-paginate-rest@^2.6.2":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.8.1.tgz#1bf7bdf6a433db1f149d32e854c0fced98806338"
-  integrity sha512-YGPZ+P5ffbVGs6uGAcg7E6FotumdSNTWQdtXm09K6KgSD0t17EA1kBCRLVsZ2nduExFdx20ux4KyL3/LzhvvCg==
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.8.2.tgz#74c803681d72e9deca1eaeccf8447192185af715"
+  integrity sha512-i3DzGnPMAS2PKseLQZm68pQONm2r3MvdYW365bpBcHvMSqNf3RGYavgS5ZXFbMmMkaj4RFgTgBuA2Hotobwg5g==
   dependencies:
     "@octokit/types" "^6.5.0"
 
 "@octokit/plugin-request-log@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz#394d59ec734cd2f122431fbaf05099861ece3c44"
-  integrity sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz#70a62be213e1edc04bb8897ee48c311482f9700d"
+  integrity sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==
 
 "@octokit/plugin-rest-endpoint-methods@4.8.0":
   version "4.8.0"
@@ -601,18 +601,18 @@
     deprecation "^2.3.1"
 
 "@octokit/request-error@^2.0.0":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.4.tgz#07dd5c0521d2ee975201274c472a127917741262"
-  integrity sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.5.tgz#72cc91edc870281ad583a42619256b380c600143"
+  integrity sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==
   dependencies:
-    "@octokit/types" "^6.0.0"
+    "@octokit/types" "^6.0.3"
     deprecation "^2.0.0"
     once "^1.4.0"
 
 "@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
-  version "5.4.12"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.12.tgz#b04826fa934670c56b135a81447be2c1723a2ffc"
-  integrity sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==
+  version "5.4.13"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.13.tgz#eec5987b3e96f984fc5f41967e001170c6d23a18"
+  integrity sha512-WcNRH5XPPtg7i1g9Da5U9dvZ6YbTffw9BN2rVezYiE7couoSyaRsw0e+Tl8uk1fArHE7Dn14U7YqUDy59WaqEw==
   dependencies:
     "@octokit/endpoint" "^6.0.1"
     "@octokit/request-error" "^2.0.0"
@@ -624,19 +624,19 @@
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^18.0.0":
-  version "18.0.14"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.0.14.tgz#a152478465746542e80697b5a5576ccb6151dc4d"
-  integrity sha512-62mKIaBb/XD2Z2KCBmAPydEk/d0IBMOnwk6DJVo36ICTnxlRPTdQwFE2LzlpBPDR52xOKPlGqb3Bnhh99atltA==
+  version "18.0.15"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.0.15.tgz#a690aabd9927a3389e285dee25da67e62b3f14ad"
+  integrity sha512-MBlZl0KeuvFMJ3210hG5xhh/jtYmMDLd5WmO49Wg4Rfg0odeivntWAyq3KofJDP2G8jskCaaOaZBKo0TeO9tFA==
   dependencies:
     "@octokit/core" "^3.2.3"
     "@octokit/plugin-paginate-rest" "^2.6.2"
     "@octokit/plugin-request-log" "^1.0.2"
     "@octokit/plugin-rest-endpoint-methods" "4.8.0"
 
-"@octokit/types@^6.0.0", "@octokit/types@^6.0.3", "@octokit/types@^6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.5.0.tgz#8f27c52d57eb4096fb05a290f4afc90194e08b19"
-  integrity sha512-mzCy7lkYQv+kM58W37uTg/mWoJ4nvRDRCkjSdqlrgA28hJEYNJTMYiGTvmq39cdtnMPJd0hshysBEAaH4D5C7w==
+"@octokit/types@^6.0.3", "@octokit/types@^6.5.0":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.5.1.tgz#0f1a016ed2220576e94df6ae2bb6a2db8f44829a"
+  integrity sha512-meP0U3ker/Nkzfif/q7JAK2LSOnuV+72F8mgfruwVX4iTQBgkShh5LSrdI9F7aC2hF3a/8AePfYh4SLzu1RuxA==
   dependencies:
     "@octokit/openapi-types" "^3.2.0"
     "@types/node" ">= 8"
@@ -8411,10 +8411,10 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
-wootils@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/wootils/-/wootils-4.3.1.tgz#47a17fa368242869ad5423a6856d6ffb17fe335f"
-  integrity sha512-fZrK5fcn18+jkGu7HosvTBLYfBOeF78eJ7jP+zzaqQswkwMHxHsezhgl7ug/J0RcV0pb8AxMYIFKT04K6p2ojw==
+wootils@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/wootils/-/wootils-4.3.2.tgz#0942ffacfc368b9df494048e4102cebac9cedac6"
+  integrity sha512-PtTECF2d+9wy550xICFL5PLqhr7jhkgEnzHMxXpgEaBpyn9IDkWoy6QO44YK2ICWVHxEc68ZWZSnperqgayrTw==
   dependencies:
     colors "^1.4.0"
     extend "^3.0.2"


### PR DESCRIPTION
### What does this PR do?

Another follow up for #61 - The `Jimple` class is not being imported, thus not being extended. I added a quick hot fix by hardcoding the definition of the file and copying it to the `types` directory after TypeScript finishes.

I also removed the `src` folder from the `types`.

### How should it be tested manually?

Install the package and try to use the types.
