### PR TITLE
07 - Add default services, the app path, and tests for the main class

### DIFF
--- a/src/app/jimpex.ts
+++ b/src/app/jimpex.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as fs from 'fs/promises';
+import fs from 'fs/promises';
 import { createServer as createHTTPSServer } from 'https';
 import { Jimple } from '@homer0/jimple';
 import { deepAssignWithOverwrite } from '@homer0/deep-assign';

--- a/src/app/jimpex.ts
+++ b/src/app/jimpex.ts
@@ -18,7 +18,19 @@ import {
   type ServerOptions as SpdyServerOptions,
 } from 'spdy';
 import express from 'express';
-import { statuses } from '../utils';
+import {
+  common as commonServices,
+  http as httpServices,
+  utils as utilsServices,
+} from '../services';
+import {
+  statuses,
+  type Controller,
+  type ControllerLike,
+  type MiddlewareLike,
+  type MiddlewareProvider,
+  type Middleware,
+} from '../utils';
 import type {
   DeepPartial,
   Express,
@@ -43,13 +55,6 @@ import type {
   JimpexEventListener,
   JimpexHealthCheckFn,
 } from '../types';
-import type {
-  Controller,
-  ControllerLike,
-  MiddlewareLike,
-  MiddlewareProvider,
-  Middleware,
-} from '../utils';
 
 export class Jimpex extends Jimple {
   protected options: JimpexOptions;
@@ -95,7 +100,7 @@ export class Jimpex extends Jimple {
           bodyParser: true,
           multer: true,
         },
-        defaultServices: {
+        services: {
           common: true,
           http: true,
           utils: true,
@@ -304,6 +309,11 @@ export class Jimpex extends Jimple {
     this.register(packageInfoProvider);
     this.register(pathUtilsProvider);
     this.register(rootFileProvider);
+    const { services: enabledServices } = this.options;
+    if (enabledServices.common) this.register(commonServices);
+    if (enabledServices.http) this.register(httpServices);
+    if (enabledServices.utils) this.register(utilsServices);
+
     this.set('events', () => new EventsHub());
     this.set('statuses', () => statuses);
   }

--- a/src/app/jimpex.ts
+++ b/src/app/jimpex.ts
@@ -114,6 +114,7 @@ export class Jimpex extends Jimple {
     this.express = express();
 
     this.setupCoreServices();
+    this.setupExpress();
     this.configurePath();
 
     this.init();

--- a/src/app/jimpex.ts
+++ b/src/app/jimpex.ts
@@ -19,9 +19,9 @@ import {
 } from 'spdy';
 import express from 'express';
 import {
-  common as commonServices,
-  http as httpServices,
-  utils as utilsServices,
+  commonServicesProvider,
+  httpServicesProvider,
+  utilsServicesProvider,
 } from '../services';
 import {
   statuses,
@@ -314,9 +314,9 @@ export class Jimpex extends Jimple {
     this.register(pathUtilsProvider);
     this.register(rootFileProvider);
     const { services: enabledServices } = this.options;
-    if (enabledServices.common) this.register(commonServices);
-    if (enabledServices.http) this.register(httpServices);
-    if (enabledServices.utils) this.register(utilsServices);
+    if (enabledServices.common) this.register(commonServicesProvider);
+    if (enabledServices.http) this.register(httpServicesProvider);
+    if (enabledServices.utils) this.register(utilsServicesProvider);
 
     this.set('events', () => new EventsHub());
     this.set('statuses', () => statuses);

--- a/src/app/jimpex.ts
+++ b/src/app/jimpex.ts
@@ -135,7 +135,7 @@ export class Jimpex extends Jimple {
     const config = this.getConfig();
     const port = config.get<number | undefined>('port');
     if (!port) {
-      throw new Error('Port is not defined');
+      throw new Error('No port configured');
     }
     this.emitEvent('beforeStart', { app: this });
     this.server = await this.createServer();
@@ -243,7 +243,10 @@ export class Jimpex extends Jimple {
     setting?: string | string[],
     asArray: boolean = false,
   ): SimpleConfig | T {
-    const config = this.get<SimpleConfig>('config');
+    const config = this.try<SimpleConfig>('config');
+    if (!config) {
+      throw new Error('The config service is not available until the app starts');
+    }
     if (typeof setting === 'undefined') {
       return config;
     }

--- a/src/app/jimpex.ts
+++ b/src/app/jimpex.ts
@@ -78,7 +78,7 @@ export class Jimpex extends Jimple {
           useParentPath: true,
         },
         configuration: {
-          default: configuration,
+          default: options?.configuration?.default || configuration,
           name: 'app',
           path: 'config/',
           hasFolder: true,

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,2 +1,2 @@
-export * as common from './common';
-export * as utils from './utils';
+export * from './common';
+export * from './utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export * from './app';
 export * from './types';
-
-export const hello = () => 'hello world';
+export * from './controllers';
+export * from './middlewares';
+export * from './services';
+export * from './utils';

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,3 +1,3 @@
-export * as common from './common';
-export * as html from './html';
-export * as utils from './utils';
+export * from './common';
+export * from './html';
+export * from './utils';

--- a/src/services/common/index.ts
+++ b/src/services/common/index.ts
@@ -3,7 +3,7 @@ import { appErrorProvider } from './appError';
 import { httpErrorProvider } from './httpError';
 import { sendFileProvider } from './sendFile';
 
-export default providers({
+export const commonServicesProvider = providers({
   appErrorProvider,
   httpErrorProvider,
   sendFileProvider,

--- a/src/services/frontend/index.ts
+++ b/src/services/frontend/index.ts
@@ -1,7 +1,7 @@
 import { providers } from '../../utils';
 import { frontendFsProvider } from './frontendFs';
 
-export default providers({
+export const frontendServicesProvider = providers({
   frontendFsProvider,
 });
 

--- a/src/services/html/index.ts
+++ b/src/services/html/index.ts
@@ -1,7 +1,7 @@
 import { providers } from '../../utils';
 import { htmlGeneratorProvider } from './htmlGenerator';
 
-export default providers({
+export const htmlServicesProvider = providers({
   htmlGeneratorProvider,
 });
 

--- a/src/services/http/index.ts
+++ b/src/services/http/index.ts
@@ -3,7 +3,7 @@ import { apiClientProvider } from './apiClient';
 import { httpProvider } from './http';
 import { responsesBuilderProvider } from './responsesBuilder';
 
-export default providers({
+export const httpServicesProvider = providers({
   apiClientProvider,
   httpProvider,
   responsesBuilderProvider,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,10 +1,5 @@
-export { default as common } from './common';
 export * from './common';
-export { default as frontend } from './frontend';
 export * from './frontend';
-export { default as html } from './html';
 export * from './html';
-export { default as http } from './http';
 export * from './http';
-export { default as utils } from './utils';
 export * from './utils';

--- a/src/services/utils/index.ts
+++ b/src/services/utils/index.ts
@@ -1,7 +1,7 @@
 import { providers } from '../../utils';
 import { ensureBearerTokenProvider } from './ensureBearerToken';
 
-export default providers({
+export const utilsServicesProvider = providers({
   ensureBearerTokenProvider,
 });
 

--- a/src/types/http.ts
+++ b/src/types/http.ts
@@ -5,6 +5,7 @@ import type { Express } from './express';
 
 export type { Response as HTTPResponse } from 'node-fetch';
 
+export type { HTTPSServer, HTTPServer };
 export type JimpexServer = Express | HTTPSServer;
 export type JimpexServerInstance = HTTPServer | HTTPSServer;
 

--- a/tests/app/jimpex.test.ts
+++ b/tests/app/jimpex.test.ts
@@ -1,0 +1,1192 @@
+/* eslint-disable no-process-env, dot-notation */
+import * as path from 'path';
+import fs from 'fs/promises';
+import {
+  https,
+  spdy,
+  express,
+  resetDependencies,
+  setupCase,
+  appLoggerProvider,
+  simpleConfigProvider,
+  envUtilsProvider,
+  packageInfoProvider,
+  pathUtilsProvider,
+  rootFileProvider,
+} from '@tests/mocks/jimpexSetup';
+import { statuses } from '@src/utils';
+import { Jimpex, jimpex } from '@src/app/jimpex';
+import { EventsHub } from '@homer0/events-hub';
+import { SimpleLogger } from '@homer0/simple-logger';
+import type {
+  JimpexOptions,
+  DeepPartial,
+  HTTPSServer,
+  Router,
+  ExpressMiddleware,
+} from '@src/types';
+
+describe('Jimpex', () => {
+  describe('class', () => {
+    beforeEach(() => {
+      delete process.env['NODE_TLS_REJECT_UNAUTHORIZED'];
+      resetDependencies();
+    });
+
+    it('should be instantiated', () => {
+      // Given
+      const {
+        express: { expressMocks },
+        wootils: { pathUtilsMocks },
+        services: { commonServices, httpServices, utilsServices },
+      } = setupCase();
+      // When
+      const sut = new Jimpex();
+      // Then
+      expect(sut).toBeInstanceOf(Jimpex);
+      expect(express).toHaveBeenCalledTimes(1);
+      expect(appLoggerProvider).toHaveBeenCalledTimes(1);
+      expect(appLoggerProvider).toHaveBeenCalledWith({
+        serviceName: 'logger',
+      });
+      expect(envUtilsProvider.register).toHaveBeenCalledTimes(1);
+      expect(envUtilsProvider.register).toHaveBeenCalledWith(sut);
+      expect(packageInfoProvider.register).toHaveBeenCalledTimes(1);
+      expect(packageInfoProvider.register).toHaveBeenCalledWith(sut);
+      expect(pathUtilsProvider.register).toHaveBeenCalledTimes(1);
+      expect(pathUtilsProvider.register).toHaveBeenCalledWith(sut);
+      expect(rootFileProvider.register).toHaveBeenCalledTimes(1);
+      expect(rootFileProvider.register).toHaveBeenCalledWith(sut);
+      expect(commonServices).toHaveBeenCalledTimes(1);
+      expect(commonServices).toHaveBeenCalledWith(sut);
+      expect(httpServices).toHaveBeenCalledTimes(1);
+      expect(httpServices).toHaveBeenCalledWith(sut);
+      expect(utilsServices).toHaveBeenCalledTimes(1);
+      expect(utilsServices).toHaveBeenCalledWith(sut);
+      expect(expressMocks.enable).toHaveBeenCalledTimes(1);
+      expect(expressMocks.enable).toHaveBeenCalledWith('trust proxy');
+      expect(expressMocks.disable).toHaveBeenCalledTimes(1);
+      expect(expressMocks.disable).toHaveBeenCalledWith('x-powered-by');
+      expect(expressMocks.use).toHaveBeenCalledTimes(4);
+      expect(expressMocks.use).toHaveBeenNthCalledWith(1, {
+        compression: true,
+      });
+      expect(expressMocks.use).toHaveBeenNthCalledWith(2, {
+        json: true,
+      });
+      expect(expressMocks.use).toHaveBeenNthCalledWith(3, {
+        urlencoded: true,
+      });
+      expect(expressMocks.use).toHaveBeenNthCalledWith(4, {
+        multerAny: true,
+      });
+      expect(pathUtilsMocks.addLocation).toHaveBeenCalledTimes(1);
+      expect(pathUtilsMocks.addLocation).toHaveBeenCalledWith(
+        'app',
+        expect.stringMatching(/src\/app\/jimpex\.ts$/),
+      );
+      expect(sut.get('router')).toEqual({
+        router: true,
+      });
+      expect(sut.get('statuses')).toBe(statuses);
+      expect(sut.getEventsHub()).toBeInstanceOf(EventsHub);
+      expect(sut.getLogger()).toBeInstanceOf(SimpleLogger);
+      expect(sut.getExpress()).toBe(expressMocks);
+      expect(sut.getInstance()).toBeUndefined();
+      expect(sut.getRoutes()).toEqual([]);
+      expect(sut.getOptions()).toEqual({
+        version: '0.0.0',
+        filesizeLimit: '15MB',
+        boot: true,
+        proxy: false,
+        path: {
+          appPath: '',
+          useParentPath: true,
+        },
+        configuration: {
+          default: {},
+          name: 'app',
+          path: 'config/',
+          hasFolder: true,
+          environmentVariable: 'CONFIG',
+          loadFromEnvironment: true,
+          defaultConfigFilename: '[app-name].config.js',
+          filenameFormat: '[app-name].[configuration-name].config.js',
+        },
+        statics: {
+          enabled: true,
+          onHome: false,
+          route: 'statics',
+          folder: '',
+        },
+        express: {
+          trustProxy: true,
+          disableXPoweredBy: true,
+          compression: true,
+          bodyParser: true,
+          multer: true,
+        },
+        services: {
+          common: true,
+          http: true,
+          utils: true,
+        },
+        healthCheck: expect.any(Function),
+      });
+    });
+
+    it('should call the basic lifecycle methods', () => {
+      // Given
+      const initFn = jest.fn();
+      const initOptionsFn = jest.fn();
+      const bootFn = jest.fn();
+      class Sut extends Jimpex {
+        override boot(): void {
+          bootFn();
+        }
+        protected override init(): void {
+          initFn();
+        }
+        protected override initOptions(): DeepPartial<JimpexOptions> {
+          initOptionsFn();
+          return {};
+        }
+      }
+      setupCase();
+      // When
+      const sut = new Sut();
+      // Then
+      expect(sut).toBeInstanceOf(Jimpex);
+      expect(initFn).toHaveBeenCalledTimes(1);
+      expect(initOptionsFn).toHaveBeenCalledTimes(1);
+      expect(bootFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be instantiated with custom options', () => {
+      // Given
+      const bootFn = jest.fn();
+      class Sut extends Jimpex {
+        override boot(): void {
+          bootFn();
+        }
+      }
+      const {
+        express: { expressMocks },
+        wootils: { pathUtilsMocks },
+        services: { commonServices, httpServices, utilsServices },
+      } = setupCase();
+      const options: DeepPartial<JimpexOptions> = {
+        version: '1.0.0',
+        filesizeLimit: '10MB',
+        boot: false,
+        proxy: true,
+        path: {
+          appPath: 'app',
+          useParentPath: false,
+        },
+        configuration: {
+          default: {
+            x: 'y',
+          },
+          name: 'config',
+          path: 'configs/',
+          hasFolder: false,
+          environmentVariable: 'CONFIGS',
+          loadFromEnvironment: false,
+          defaultConfigFilename: '[app-name].xconfig.js',
+          filenameFormat: '[app-name].[configuration-name].xconfig.js',
+        },
+        statics: {
+          enabled: false,
+          onHome: true,
+          route: 'statics',
+          folder: 'statics',
+        },
+        express: {
+          trustProxy: false,
+          disableXPoweredBy: false,
+          compression: false,
+          bodyParser: false,
+          multer: false,
+        },
+        services: {
+          common: false,
+          http: false,
+          utils: false,
+        },
+        healthCheck: () => {},
+      };
+      // When
+      const sut = new Sut(options);
+      // Then
+      expect(bootFn).toHaveBeenCalledTimes(0);
+      expect(commonServices).toHaveBeenCalledTimes(0);
+      expect(httpServices).toHaveBeenCalledTimes(0);
+      expect(utilsServices).toHaveBeenCalledTimes(0);
+      expect(expressMocks.enable).toHaveBeenCalledTimes(0);
+      expect(expressMocks.disable).toHaveBeenCalledTimes(0);
+      expect(expressMocks.use).toHaveBeenCalledTimes(0);
+      expect(pathUtilsMocks.addLocation).toHaveBeenCalledTimes(1);
+      expect(pathUtilsMocks.addLocation).toHaveBeenCalledWith(
+        'app',
+        options.path!.appPath,
+      );
+      expect(sut.getOptions()).toEqual(options);
+    });
+
+    it('should overwrite the options with the protected method', () => {
+      // Given
+      const customOptions = {
+        version: '1.0.0',
+        filesizeLimit: '10MB',
+        configuration: {
+          default: {
+            x: 'y',
+          },
+          name: 'config',
+          path: 'configs/',
+          hasFolder: false,
+          environmentVariable: 'CONFIGS',
+          loadFromEnvironment: false,
+          defaultConfigFilename: '[app-name].xconfig.js',
+          filenameFormat: '[app-name].[configuration-name].xconfig.js',
+        },
+      };
+      class Sut extends Jimpex {
+        protected override initOptions(): DeepPartial<JimpexOptions> {
+          return customOptions;
+        }
+      }
+      setupCase();
+      // When
+      const sut = new Sut();
+      // Then
+      expect(sut.getOptions()).toEqual(expect.objectContaining(customOptions));
+    });
+
+    it('should disable the TLS validation (for dev)', () => {
+      // Given
+      const {
+        wootils: { loggerMocks },
+      } = setupCase();
+      // When
+      const prevStatus = process.env['NODE_TLS_REJECT_UNAUTHORIZED'];
+      const sut = new Jimpex();
+      sut.disableTLSValidation();
+      // Then
+      expect(prevStatus).toBeUndefined();
+      expect(process.env['NODE_TLS_REJECT_UNAUTHORIZED']).toBe('0');
+      expect(loggerMocks.warn).toHaveBeenCalledTimes(1);
+      expect(loggerMocks.warn).toHaveBeenCalledWith('TLS validation has been disabled');
+    });
+
+    it("should throw an error if the app path can't be determined", () => {
+      // Given
+      setupCase();
+      // When/Then
+      expect(
+        () =>
+          new Jimpex({
+            path: {
+              appPath: '',
+              useParentPath: false,
+            },
+          }),
+      ).toThrow(/The app location cannot be determined/i);
+    });
+
+    describe('health check', () => {
+      beforeEach(resetDependencies);
+
+      it('should return `true` as default', async () => {
+        // Given
+        setupCase();
+        // When
+        const sut = new Jimpex();
+        const result = await sut.isHealthy();
+        // Then
+        expect(result).toBe(true);
+      });
+
+      it('should be overwriten by the options', async () => {
+        // Given
+        setupCase();
+        const healthStatus = false;
+        const healthCheck = jest.fn().mockResolvedValueOnce(healthStatus);
+        const options: DeepPartial<JimpexOptions> = {
+          healthCheck,
+        };
+        // When
+        const sut = new Jimpex(options);
+        const result = await sut.isHealthy();
+        // Then
+        expect(result).toBe(healthStatus);
+        expect(healthCheck).toHaveBeenCalledWith(sut);
+      });
+    });
+
+    describe('events', () => {
+      beforeEach(resetDependencies);
+
+      it('should proxy `on` and `once`', () => {
+        // Given
+        setupCase();
+        const events = {
+          on: jest.fn(),
+          once: jest.fn(),
+        };
+        const onListener = () => {};
+        const onceListener = () => {};
+        // When
+        const sut = new Jimpex();
+        sut.set('events', () => events);
+        sut.on('afterStart', onListener);
+        sut.once('afterStart', onceListener);
+        // Then
+        expect(events.on).toHaveBeenCalledTimes(1);
+        expect(events.on).toHaveBeenCalledWith('afterStart', onListener);
+        expect(events.once).toHaveBeenCalledTimes(1);
+        expect(events.once).toHaveBeenCalledWith('afterStart', onceListener);
+      });
+    });
+
+    describe('server', () => {
+      describe('basic', () => {
+        beforeEach(resetDependencies);
+
+        it('should start and stop the server', async () => {
+          // Given
+          const onBeforeStart = jest.fn();
+          const onStart = jest.fn();
+          const onAfterStart = jest.fn();
+          const onBeforeStop = jest.fn();
+          const onAfterStop = jest.fn();
+          const {
+            wootils: { configMocks, loggerMocks },
+            express: { expressMocks, instanceMock },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          // When
+          const sut = new Jimpex();
+          const events = sut.getEventsHub();
+          events.on('beforeStart', onBeforeStart);
+          events.on('start', onStart);
+          events.on('afterStart', onAfterStart);
+          events.on('beforeStop', onBeforeStop);
+          events.on('afterStop', onAfterStop);
+          const instanceBeforeStart = sut.getInstance();
+          await sut.start();
+          const instanceAfterStart = sut.getInstance();
+          sut.stop();
+          // Then
+          expect(instanceBeforeStart).toBeUndefined();
+          expect(instanceAfterStart).toBe(instanceMock);
+          expect(expressMocks.listen).toHaveBeenCalledTimes(1);
+          expect(expressMocks.listen).toHaveBeenCalledWith(port, expect.any(Function));
+          expect(instanceMock.close).toHaveBeenCalledTimes(1);
+          expect(onBeforeStart).toHaveBeenCalledTimes(1);
+          expect(onBeforeStart).toHaveBeenCalledWith({ app: sut });
+          expect(onStart).toHaveBeenCalledTimes(1);
+          expect(onStart).toHaveBeenCalledWith({ app: sut });
+          expect(onAfterStart).toHaveBeenCalledTimes(1);
+          expect(onAfterStart).toHaveBeenCalledWith({ app: sut });
+          expect(onBeforeStop).toHaveBeenCalledTimes(1);
+          expect(onBeforeStop).toHaveBeenCalledWith({ app: sut });
+          expect(onAfterStop).toHaveBeenCalledTimes(1);
+          expect(onAfterStop).toHaveBeenCalledWith({ app: sut });
+          expect(loggerMocks.success).toHaveBeenCalledTimes(1);
+          expect(loggerMocks.success).toHaveBeenCalledWith(`Starting on port ${port}`);
+          expect(configMocks.loadFromFile).toHaveBeenCalledTimes(1);
+          expect(configMocks.loadFromFile).toHaveBeenCalledWith('', true, false);
+          expect(configMocks.loadFromEnv).toHaveBeenCalledTimes(1);
+          expect(simpleConfigProvider).toHaveBeenCalledTimes(1);
+          expect(simpleConfigProvider).toHaveBeenCalledWith({
+            name: 'app',
+            defaultConfig: {},
+            defaultConfigFilename: 'app.config.js',
+            envVarName: 'CONFIG',
+            path: `config${path.sep}app${path.sep}`,
+            filenameFormat: 'app.[name].config.js',
+          });
+        });
+
+        it('should throw error if theres no port configured', async () => {
+          // Given
+          setupCase();
+          // When/Then
+          const sut = new Jimpex();
+          await expect(() => sut.start()).rejects.toThrow(/No port configured/i);
+        });
+
+        it('should invoke a callback when starting', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onStart = jest.fn();
+          // When
+          const sut = new Jimpex();
+          await sut.start(onStart);
+          // Then
+          expect(onStart).toHaveBeenCalledTimes(1);
+          expect(onStart).toHaveBeenCalledWith(sut.getConfig());
+        });
+
+        it("shouldn't do anything if `stop` is called before `start`", async () => {
+          // Given
+          const onBeforeStop = jest.fn();
+          setupCase();
+          // When
+          const sut = new Jimpex();
+          const events = sut.getEventsHub();
+          events.on('beforeStop', onBeforeStop);
+          sut.stop();
+          // Then
+          expect(onBeforeStop).toHaveBeenCalledTimes(0);
+        });
+      });
+
+      describe('statics', () => {
+        beforeEach(resetDependencies);
+
+        it('should mount the statics middleware/controller', async () => {
+          // Given
+          const {
+            express: { staticMock, expressMocks },
+            wootils: { configMocks, pathUtilsMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onControllerWillBeMounted = jest.fn(<T>(target: T): T => target);
+          // When
+          const sut = new Jimpex();
+          sut.on('controllerWillBeMounted', onControllerWillBeMounted);
+          await sut.start();
+          // Then
+          expect(staticMock).toHaveBeenCalledTimes(1);
+          expect(staticMock).toHaveBeenCalledWith('statics');
+          expect(pathUtilsMocks.joinFrom).toHaveBeenCalledTimes(1);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenCalledWith('app', 'statics');
+          expect(expressMocks.use).toHaveBeenCalledTimes(5);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(1, {
+            compression: true,
+          });
+          expect(expressMocks.use).toHaveBeenNthCalledWith(2, {
+            json: true,
+          });
+          expect(expressMocks.use).toHaveBeenNthCalledWith(3, {
+            urlencoded: true,
+          });
+          expect(expressMocks.use).toHaveBeenNthCalledWith(4, {
+            multerAny: true,
+          });
+          expect(expressMocks.use).toHaveBeenNthCalledWith(5, '/statics', {
+            static: true,
+          });
+          expect(onControllerWillBeMounted).toHaveBeenCalledTimes(1);
+          expect(onControllerWillBeMounted).toHaveBeenCalledWith(
+            {
+              static: true,
+            },
+            {
+              route: '/statics',
+              controller: expect.objectContaining({
+                connect: expect.any(Function),
+                controller: true,
+              }),
+              app: sut,
+            },
+          );
+        });
+
+        it('should mount the statics middleware/controller on the home path', async () => {
+          // Given
+          const {
+            express: { staticMock, expressMocks },
+            wootils: { configMocks, pathUtilsMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          // When
+          const sut = new Jimpex({
+            statics: {
+              onHome: true,
+            },
+          });
+          await sut.start();
+          // Then
+          expect(staticMock).toHaveBeenCalledTimes(1);
+          expect(staticMock).toHaveBeenCalledWith('statics');
+          expect(pathUtilsMocks.joinFrom).toHaveBeenCalledTimes(1);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenCalledWith('home', 'statics');
+          expect(expressMocks.use).toHaveBeenCalledTimes(5);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(5, '/statics', {
+            static: true,
+          });
+        });
+
+        it('should allow to add multiple static middlewares/controllers when subclassed', async () => {
+          // Given
+          const sameRoute = 'same-route-statics';
+          const differentRoute = 'different-route-statics';
+          const differentPath = 'different-path-statics';
+          class Sut extends Jimpex {
+            override boot(): void {
+              this.addStaticsFolder(sameRoute);
+              this.addStaticsFolder(differentRoute, differentPath);
+            }
+          }
+          const {
+            express: { staticMock, expressMocks },
+            wootils: { configMocks, pathUtilsMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          // When
+          const sut = new Sut();
+          await sut.start();
+          // Then
+          expect(staticMock).toHaveBeenCalledTimes(3);
+          expect(staticMock).toHaveBeenNthCalledWith(2, sameRoute);
+          expect(staticMock).toHaveBeenNthCalledWith(3, differentPath);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenCalledTimes(3);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(2, 'app', sameRoute);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(
+            3,
+            'app',
+            differentPath,
+          );
+          expect(expressMocks.use).toHaveBeenCalledTimes(7);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(6, `/${sameRoute}`, {
+            static: true,
+          });
+          expect(expressMocks.use).toHaveBeenNthCalledWith(7, `/${differentRoute}`, {
+            static: true,
+          });
+        });
+      });
+
+      describe('listen', () => {
+        beforeEach(resetDependencies);
+
+        it('should start the server', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { instanceMock },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          // When
+          const sut = new Jimpex();
+          await sut.listen();
+          // Then
+          expect(sut.getInstance()).toBe(instanceMock);
+        });
+
+        it('should overwrite the port on the config', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { instanceMock },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          // When
+          const sut = new Jimpex();
+          await sut.listen(port);
+          // Then
+          expect(sut.getInstance()).toBe(instanceMock);
+          expect(configMocks.set).toHaveBeenCalledTimes(1);
+          expect(configMocks.set).toHaveBeenCalledWith('port', port);
+        });
+
+        it('should invoke a callback when starting', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { instanceMock },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onStart = jest.fn();
+          // When
+          const sut = new Jimpex();
+          await sut.listen(undefined, onStart);
+          // Then
+          expect(sut.getInstance()).toBe(instanceMock);
+          expect(onStart).toHaveBeenCalledTimes(1);
+          expect(onStart).toHaveBeenCalledWith(sut.getConfig());
+        });
+      });
+
+      describe('config', () => {
+        beforeEach(resetDependencies);
+
+        it('should throw an error if trying to access it before starting the server', () => {
+          // Given
+          setupCase();
+          // When/Then
+          const sut = new Jimpex();
+          expect(() => sut.getConfig()).toThrow(
+            /The config service is not available until the app starts/i,
+          );
+        });
+
+        it('should return the config service', async () => {
+          // Given
+          const {
+            wootils: { configMocks, config },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          // When
+          const sut = new Jimpex();
+          await sut.listen();
+          const result = sut.getConfig();
+          // Then
+          expect(result).toBe(config);
+        });
+      });
+
+      describe('https', () => {
+        beforeEach(() => {
+          resetDependencies();
+          jest.spyOn(fs, 'readFile').mockReset();
+        });
+
+        it('should start a secure server', async () => {
+          // Given
+          const {
+            wootils: { configMocks, pathUtilsMocks },
+            express: { expressMocks, instanceMock },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          const caPath = 'ca';
+          const certPath = 'cert';
+          const httpsConfig = {
+            enabled: true,
+            credentials: {
+              onHome: true,
+              ca: caPath,
+              cert: certPath,
+            },
+          };
+          configMocks.get.mockImplementationOnce(() => [undefined, httpsConfig]);
+          const caFile = 'ca-file';
+          const certFile = 'cert-file';
+          jest
+            .spyOn(fs, 'readFile')
+            .mockResolvedValueOnce(caFile)
+            .mockResolvedValueOnce(certFile);
+          https.createServer.mockReturnValueOnce(expressMocks as unknown as HTTPSServer);
+          // When
+          const sut = new Jimpex();
+          await sut.start();
+          // Then
+          expect(sut.getInstance()).toBe(instanceMock);
+          expect(fs.readFile).toHaveBeenCalledTimes(2);
+          expect(fs.readFile).toHaveBeenNthCalledWith(1, caPath, 'utf8');
+          expect(fs.readFile).toHaveBeenNthCalledWith(2, certPath, 'utf8');
+          expect(pathUtilsMocks.joinFrom).toHaveBeenCalledTimes(3);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(1, 'app', 'statics');
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(2, 'home', caPath);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(3, 'home', certPath);
+          expect(https.createServer).toHaveBeenCalledTimes(1);
+          expect(https.createServer).toHaveBeenCalledWith(
+            {
+              ca: caFile,
+              cert: certFile,
+            },
+            expressMocks,
+          );
+        });
+
+        it('should load the credentials from the `app` location', async () => {
+          // Given
+          const {
+            wootils: { configMocks, pathUtilsMocks },
+            express: { expressMocks, instanceMock },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          const caPath = 'ca';
+          const certPath = 'cert';
+          const httpsConfig = {
+            enabled: true,
+            credentials: {
+              onHome: false,
+              ca: caPath,
+              cert: certPath,
+            },
+          };
+          configMocks.get.mockImplementationOnce(() => [undefined, httpsConfig]);
+          const caFile = 'ca-file';
+          const certFile = 'cert-file';
+          jest
+            .spyOn(fs, 'readFile')
+            .mockResolvedValueOnce(caFile)
+            .mockResolvedValueOnce(certFile);
+          https.createServer.mockReturnValueOnce(expressMocks as unknown as HTTPSServer);
+          // When
+          const sut = new Jimpex();
+          await sut.start();
+          // Then
+          expect(sut.getInstance()).toBe(instanceMock);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(1, 'app', 'statics');
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(2, 'app', caPath);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(3, 'app', certPath);
+          expect(https.createServer).toHaveBeenCalledTimes(1);
+        });
+
+        it('should throw an error if no credentials object is provided', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          const httpsConfig = {
+            enabled: true,
+          };
+          configMocks.get.mockImplementationOnce(() => [undefined, httpsConfig]);
+          // When/Then
+          const sut = new Jimpex();
+          await expect(() => sut.start()).rejects.toThrow(
+            /The `credentials` object on the HTTPS settings is missing/i,
+          );
+        });
+
+        it("should throw an error if no credentials' files are provided", async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          const httpsConfig = {
+            enabled: true,
+            credentials: {},
+          };
+          configMocks.get.mockImplementationOnce(() => [undefined, httpsConfig]);
+          // When/Then
+          const sut = new Jimpex();
+          await expect(() => sut.start()).rejects.toThrow(
+            /No credentials were found for HTTPS/i,
+          );
+        });
+      });
+
+      describe('http2', () => {
+        beforeEach(() => {
+          resetDependencies();
+          jest.spyOn(fs, 'readFile').mockReset();
+        });
+
+        it('should start a spdy server', async () => {
+          // Given
+          const {
+            wootils: { configMocks, pathUtilsMocks },
+            express: { expressMocks, instanceMock },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          const caPath = 'ca';
+          const certPath = 'cert';
+          const httpsConfig = {
+            enabled: true,
+            credentials: {
+              onHome: true,
+              ca: caPath,
+              cert: certPath,
+            },
+          };
+          const http2Config = {
+            enabled: true,
+            spdy: 'some-options',
+          };
+          configMocks.get.mockImplementationOnce(() => [http2Config, httpsConfig]);
+          const caFile = 'ca-file';
+          const certFile = 'cert-file';
+          jest
+            .spyOn(fs, 'readFile')
+            .mockResolvedValueOnce(caFile)
+            .mockResolvedValueOnce(certFile);
+          spdy.createServer.mockReturnValueOnce(expressMocks as unknown as HTTPSServer);
+          // When
+          const sut = new Jimpex();
+          await sut.start();
+          // Then
+          expect(sut.getInstance()).toBe(instanceMock);
+          expect(fs.readFile).toHaveBeenCalledTimes(2);
+          expect(fs.readFile).toHaveBeenNthCalledWith(1, caPath, 'utf8');
+          expect(fs.readFile).toHaveBeenNthCalledWith(2, certPath, 'utf8');
+          expect(pathUtilsMocks.joinFrom).toHaveBeenCalledTimes(3);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(1, 'app', 'statics');
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(2, 'home', caPath);
+          expect(pathUtilsMocks.joinFrom).toHaveBeenNthCalledWith(3, 'home', certPath);
+          expect(spdy.createServer).toHaveBeenCalledTimes(1);
+          expect(spdy.createServer).toHaveBeenCalledWith(
+            {
+              ca: caFile,
+              cert: certFile,
+              spdy: 'some-options',
+            },
+            expressMocks,
+          );
+        });
+
+        it('should throw error if HTTPS is not enabled', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          const httpsConfig = {};
+          const http2Config = {
+            enabled: true,
+          };
+          configMocks.get.mockImplementationOnce(() => [http2Config, httpsConfig]);
+          // When/Then
+          const sut = new Jimpex();
+          await expect(() => sut.start()).rejects.toThrow(
+            /HTTP2 requires for HTTPS to be enabled/,
+          );
+        });
+      });
+
+      describe('mount', () => {
+        beforeEach(resetDependencies);
+
+        it('should mount a controller', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { expressMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onControllerWillBeMounted = jest.fn(<T>(target: T): T => target);
+          const onRouteAdded = jest.fn();
+          const controllerObj = {
+            theControllerToMount: true,
+          };
+          const controller = {
+            connect: jest.fn(() => controllerObj as unknown as Router),
+            controller: true as const,
+          };
+          const route = 'my-route';
+          // When
+          const sut = new Jimpex();
+          sut.on('controllerWillBeMounted', onControllerWillBeMounted);
+          sut.on('routeAdded', onRouteAdded);
+          sut.mount(route, controller);
+          await sut.start();
+          // Then
+          expect(controller.connect).toHaveBeenCalledTimes(1);
+          expect(controller.connect).toHaveBeenCalledWith(sut, route);
+          expect(expressMocks.use).toHaveBeenCalledTimes(6);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(6, route, controllerObj);
+          expect(onControllerWillBeMounted).toHaveBeenCalledTimes(2);
+          expect(onControllerWillBeMounted).toHaveBeenNthCalledWith(2, controllerObj, {
+            route,
+            controller,
+            app: sut,
+          });
+          expect(onRouteAdded).toHaveBeenCalledTimes(2);
+          expect(onRouteAdded).toHaveBeenNthCalledWith(2, {
+            route,
+            app: sut,
+          });
+        });
+
+        it('should mount a middleware', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { expressMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onControllerWillBeMounted = jest.fn(<T>(target: T): T => target);
+          const middlewareObj = {
+            theControllerToMount: true,
+          };
+          const middleware = {
+            connect: jest.fn(() => middlewareObj as unknown as ExpressMiddleware),
+            middleware: true as const,
+          };
+          const route = 'my-route';
+          // When
+          const sut = new Jimpex();
+          sut.on('controllerWillBeMounted', onControllerWillBeMounted);
+          sut.mount(route, middleware);
+          await sut.start();
+          // Then
+          expect(middleware.connect).toHaveBeenCalledTimes(1);
+          expect(middleware.connect).toHaveBeenCalledWith(sut, route);
+          expect(expressMocks.use).toHaveBeenCalledTimes(6);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(6, route, middlewareObj);
+          expect(onControllerWillBeMounted).toHaveBeenCalledTimes(2);
+          expect(onControllerWillBeMounted).toHaveBeenNthCalledWith(2, middlewareObj, {
+            route,
+            controller: middleware,
+            app: sut,
+          });
+        });
+
+        it("shouldn't mount a middleware that returns undefined", async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { expressMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onControllerWillBeMounted = jest.fn(<T>(target: T): T => target);
+          const middleware = {
+            connect: jest.fn(),
+            middleware: true as const,
+          };
+          const route = 'my-route';
+          // When
+          const sut = new Jimpex();
+          sut.on('controllerWillBeMounted', onControllerWillBeMounted);
+          sut.mount(route, middleware);
+          await sut.start();
+          // Then
+          expect(middleware.connect).toHaveBeenCalledTimes(1);
+          expect(middleware.connect).toHaveBeenCalledWith(sut, route);
+          expect(expressMocks.use).toHaveBeenCalledTimes(5);
+          expect(onControllerWillBeMounted).toHaveBeenCalledTimes(1);
+        });
+
+        it('should mount a provider controller', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { expressMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const controllerObj = {
+            theControllerToMount: true,
+          };
+          const controller = {
+            connect: jest.fn(() => controllerObj as unknown as Router),
+            controller: true as const,
+          };
+          const provider = {
+            register: jest.fn(() => controller),
+            provider: true as const,
+          };
+          const route = 'my-route';
+          // When
+          const sut = new Jimpex();
+          sut.mount(route, provider);
+          await sut.start();
+          // Then
+          expect(provider.register).toHaveBeenCalledTimes(1);
+          expect(provider.register).toHaveBeenCalledWith(sut, route);
+          expect(controller.connect).toHaveBeenCalledTimes(1);
+          expect(controller.connect).toHaveBeenCalledWith(sut, route);
+          expect(expressMocks.use).toHaveBeenCalledTimes(6);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(6, route, controllerObj);
+        });
+
+        it('should mount an express middleware', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { expressMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const middleware = () => {};
+          const route = 'my-route';
+          // When
+          const sut = new Jimpex();
+          sut.mount(route, middleware);
+          await sut.start();
+          // Then
+          expect(expressMocks.use).toHaveBeenCalledTimes(6);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(6, route, middleware);
+        });
+      });
+
+      describe('use', () => {
+        beforeEach(resetDependencies);
+
+        it('should use a middleware', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { expressMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onMiddlewareWillBeUsed = jest.fn(<T>(target: T): T => target);
+          const middlewareObj = {
+            theControllerToMount: true,
+          };
+          const middleware = {
+            connect: jest.fn(() => middlewareObj as unknown as ExpressMiddleware),
+            middleware: true as const,
+          };
+          // When
+          const sut = new Jimpex();
+          sut.on('middlewareWillBeUsed', onMiddlewareWillBeUsed);
+          sut.use(middleware);
+          await sut.start();
+          // Then
+          expect(middleware.connect).toHaveBeenCalledTimes(1);
+          expect(middleware.connect).toHaveBeenCalledWith(sut);
+          expect(expressMocks.use).toHaveBeenCalledTimes(6);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(6, middlewareObj);
+          expect(onMiddlewareWillBeUsed).toHaveBeenCalledTimes(1);
+          expect(onMiddlewareWillBeUsed).toHaveBeenNthCalledWith(1, middlewareObj, {
+            app: sut,
+          });
+        });
+
+        it("shouldn't use a middleware that returns undefined", async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { expressMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onMiddlewareWillBeUsed = jest.fn(<T>(target: T): T => target);
+          const middleware = {
+            connect: jest.fn(),
+            middleware: true as const,
+          };
+          // When
+          const sut = new Jimpex();
+          sut.on('middlewareWillBeUsed', onMiddlewareWillBeUsed);
+          sut.use(middleware);
+          await sut.start();
+          // Then
+          expect(middleware.connect).toHaveBeenCalledTimes(1);
+          expect(middleware.connect).toHaveBeenCalledWith(sut);
+          expect(expressMocks.use).toHaveBeenCalledTimes(5);
+          expect(onMiddlewareWillBeUsed).toHaveBeenCalledTimes(0);
+        });
+
+        it('should use a middleware a provider', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { expressMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onMiddlewareWillBeUsed = jest.fn(<T>(target: T): T => target);
+          const middlewareObj = {
+            theControllerToMount: true,
+          };
+          const middleware = {
+            connect: jest.fn(() => middlewareObj as unknown as ExpressMiddleware),
+            middleware: true as const,
+          };
+          const provider = {
+            register: jest.fn(() => middleware),
+            provider: true as const,
+          };
+          // When
+          const sut = new Jimpex();
+          sut.on('middlewareWillBeUsed', onMiddlewareWillBeUsed);
+          sut.use(provider);
+          await sut.start();
+          // Then
+          expect(middleware.connect).toHaveBeenCalledTimes(1);
+          expect(middleware.connect).toHaveBeenCalledWith(sut);
+          expect(provider.register).toHaveBeenCalledTimes(1);
+          expect(provider.register).toHaveBeenCalledWith(sut);
+          expect(expressMocks.use).toHaveBeenCalledTimes(6);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(6, middlewareObj);
+          expect(onMiddlewareWillBeUsed).toHaveBeenCalledTimes(1);
+          expect(onMiddlewareWillBeUsed).toHaveBeenNthCalledWith(1, middlewareObj, {
+            app: sut,
+          });
+        });
+
+        it('should use an express middleware', async () => {
+          // Given
+          const {
+            wootils: { configMocks },
+            express: { expressMocks },
+          } = setupCase();
+          const port = 2509;
+          configMocks.get.mockImplementationOnce(() => port);
+          configMocks.get.mockImplementationOnce(() => []);
+          const onMiddlewareWillBeUsed = jest.fn(<T>(target: T): T => target);
+          const middleware = () => {};
+          // When
+          const sut = new Jimpex();
+          sut.on('middlewareWillBeUsed', onMiddlewareWillBeUsed);
+          sut.use(middleware);
+          await sut.start();
+          // Then
+          expect(expressMocks.use).toHaveBeenCalledTimes(6);
+          expect(expressMocks.use).toHaveBeenNthCalledWith(6, middleware);
+          expect(onMiddlewareWillBeUsed).toHaveBeenCalledTimes(1);
+          expect(onMiddlewareWillBeUsed).toHaveBeenNthCalledWith(1, middleware, {
+            app: sut,
+          });
+        });
+      });
+    });
+  });
+
+  describe('shorthand function', () => {
+    it('should create a Jimpex instance', () => {
+      // Given
+      const customOptions = {
+        version: '1.0.0',
+        filesizeLimit: '10MB',
+        configuration: {
+          default: {
+            x: 'y',
+          },
+          name: 'config',
+          path: 'configs/',
+          hasFolder: false,
+          environmentVariable: 'CONFIGS',
+          loadFromEnvironment: false,
+          defaultConfigFilename: '[app-name].xconfig.js',
+          filenameFormat: '[app-name].[configuration-name].xconfig.js',
+        },
+      };
+      setupCase();
+      // When
+      const sut = jimpex(customOptions);
+      // Then
+      expect(sut).toBeInstanceOf(Jimpex);
+      expect(sut.getOptions()).toEqual(expect.objectContaining(customOptions));
+    });
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,8 +1,0 @@
-import { hello } from '@src/index';
-
-describe('hello', () => {
-  it('should print the message', () => {
-    // Given/When/Then
-    expect(hello()).toBe('hello world');
-  });
-});

--- a/tests/mocks/config.ts
+++ b/tests/mocks/config.ts
@@ -1,10 +1,13 @@
-import { SimpleConfig } from '@homer0/simple-config';
+import type { SimpleConfig } from '@homer0/simple-config';
 
 export type ConfigMockMocks = {
   get: jest.Mock<unknown, Parameters<SimpleConfig['get']>>;
+  set: jest.Mock<unknown, Parameters<SimpleConfig['set']>>;
   getConfig: jest.Mock<unknown>;
   canSwitchConfigs: jest.Mock<boolean>;
   switch: jest.Mock<unknown, Parameters<SimpleConfig['switch']>>;
+  loadFromFile: jest.Mock<unknown, Parameters<SimpleConfig['loadFromFile']>>;
+  loadFromEnv: jest.Mock<unknown, Parameters<SimpleConfig['loadFromEnv']>>;
 };
 
 export type ConfigMockResult = {
@@ -14,30 +17,44 @@ export type ConfigMockResult = {
 
 export const getConfigMock = (): ConfigMockResult => {
   const mocks = {
+    set: jest.fn(),
     get: jest.fn(),
     getConfig: jest.fn(),
     canSwitchConfigs: jest.fn(),
     switch: jest.fn(),
+    loadFromFile: jest.fn(),
+    loadFromEnv: jest.fn(),
   };
-  class MockedConfig extends SimpleConfig {
-    override get<T = unknown>(...args: Parameters<SimpleConfig['get']>): T {
+  class MockedConfig {
+    get<T = unknown>(...args: Parameters<SimpleConfig['get']>): T {
       return mocks.get(...args) as T;
     }
-    override getConfig<T = unknown>(): T {
+    set<T = unknown>(...args: Parameters<SimpleConfig['set']>): T {
+      return mocks.set(...args) as T;
+    }
+    getConfig<T = unknown>(): T {
       return mocks.getConfig() as T;
     }
-    override canSwitchConfigs(): boolean {
+    canSwitchConfigs(): boolean {
       return mocks.canSwitchConfigs();
     }
-    override switch<T = unknown>(
-      ...args: Parameters<SimpleConfig['switch']>
-    ): Promise<T> {
+    switch<T = unknown>(...args: Parameters<SimpleConfig['switch']>): Promise<T> {
       return mocks.switch(...args);
+    }
+    loadFromFile<T = unknown>(
+      ...args: Parameters<SimpleConfig['loadFromFile']>
+    ): Promise<T> {
+      return mocks.loadFromFile(...args);
+    }
+    loadFromEnv<T = unknown>(
+      ...args: Parameters<SimpleConfig['loadFromEnv']>
+    ): Promise<T> {
+      return mocks.loadFromEnv(...args);
     }
   }
 
   return {
-    config: new MockedConfig(),
+    config: new MockedConfig() as SimpleConfig,
     configMocks: mocks,
   };
 };

--- a/tests/mocks/jimpexSetup.ts
+++ b/tests/mocks/jimpexSetup.ts
@@ -52,9 +52,9 @@ import {
 import type { Express, ExpressMiddleware, Router } from '@src/types';
 import type { Jimpex } from '@src/app/jimpex';
 import {
-  common as commonServices,
-  http as httpServices,
-  utils as utilsServices,
+  commonServicesProvider,
+  httpServicesProvider,
+  utilsServicesProvider,
 } from '@src/services';
 import {
   getPathUtilsMock,
@@ -282,15 +282,15 @@ export const setupServices = (options: SetupServicesOptions = {}): SetupServices
   } = options;
   const mocks = {
     commonServices: jest
-      .spyOn(commonServices, 'register')
+      .spyOn(commonServicesProvider, 'register')
       .mockClear()
       .mockImplementationOnce(commonServicesRegister),
     httpServices: jest
-      .spyOn(httpServices, 'register')
+      .spyOn(httpServicesProvider, 'register')
       .mockClear()
       .mockImplementationOnce(httpServicesRegister),
     utilsServices: jest
-      .spyOn(utilsServices, 'register')
+      .spyOn(utilsServicesProvider, 'register')
       .mockClear()
       .mockImplementationOnce(utilsServicesRegister),
   };

--- a/tests/mocks/jimpexSetup.ts
+++ b/tests/mocks/jimpexSetup.ts
@@ -1,0 +1,321 @@
+jest.mock('https');
+jest.mock('spdy');
+jest.mock('express');
+jest.mock('compression');
+jest.mock('body-parser', () => ({
+  json: jest.fn(),
+  urlencoded: jest.fn(),
+}));
+jest.mock('multer');
+jest.mock('@homer0/simple-logger');
+jest.mock('@homer0/path-utils', () => ({
+  pathUtilsProvider: {
+    register: jest.fn(),
+    provider: true,
+  },
+}));
+jest.mock('@homer0/simple-config');
+jest.mock('@homer0/env-utils', () => ({
+  envUtilsProvider: {
+    register: jest.fn(),
+    provider: true,
+  },
+}));
+jest.mock('@homer0/package-info', () => ({
+  packageInfoProvider: {
+    register: jest.fn(),
+    provider: true,
+  },
+}));
+jest.mock('@homer0/root-file', () => ({
+  rootFileProvider: {
+    register: jest.fn(),
+    provider: true,
+  },
+}));
+
+import originalHTTPS from 'https';
+import originalSpdy from 'spdy';
+import originalExpress from 'express';
+import originalCompression from 'compression';
+import originalBodyParser from 'body-parser';
+import originalMulter from 'multer';
+import { appLoggerProvider as originalAppLoggerProvider } from '@homer0/simple-logger';
+import { envUtilsProvider as originalEnvUtilsProvider } from '@homer0/env-utils';
+import { packageInfoProvider as originalPackageInfoProvider } from '@homer0/package-info';
+import { pathUtilsProvider as originalPathUtilsProvider } from '@homer0/path-utils';
+import { rootFileProvider as originalRootFileProvider } from '@homer0/root-file';
+import {
+  SimpleConfig,
+  simpleConfigProvider as originalSimpleConfigProvider,
+} from '@homer0/simple-config';
+import type { Express, ExpressMiddleware, Router } from '@src/types';
+import type { Jimpex } from '@src/app/jimpex';
+import {
+  common as commonServices,
+  http as httpServices,
+  utils as utilsServices,
+} from '@src/services';
+import {
+  getPathUtilsMock,
+  type PathUtilsMockOptions,
+  type PathUtilsMockMocks,
+} from './pathUtils';
+import { getLoggerMock, type LoggerMockMocks } from './logger';
+import { getConfigMock, type ConfigMockMocks } from './config';
+
+export const https = originalHTTPS as unknown as jest.Mocked<typeof originalHTTPS>;
+export const spdy = originalSpdy as unknown as jest.Mocked<typeof originalSpdy>;
+
+export const express = originalExpress as unknown as jest.MockInstance<
+  ReturnType<typeof originalExpress>,
+  jest.ArgsType<typeof originalExpress>
+> & {
+  Router: jest.Mock<Router, []>;
+  static: jest.Mock<unknown, [string]>;
+};
+
+export const compression = originalCompression as unknown as jest.MockInstance<
+  ReturnType<typeof originalCompression>,
+  jest.ArgsType<typeof originalCompression>
+>;
+export const bodyParser = originalBodyParser as unknown as {
+  json: jest.Mock;
+  urlencoded: jest.Mock;
+};
+
+export const multer = originalMulter as unknown as jest.MockInstance<
+  ReturnType<typeof originalMulter>,
+  jest.ArgsType<typeof originalMulter>
+>;
+
+export const appLoggerProvider =
+  originalAppLoggerProvider as unknown as jest.MockInstance<
+    ReturnType<typeof originalAppLoggerProvider>,
+    jest.ArgsType<typeof originalAppLoggerProvider>
+  >;
+
+export const pathUtilsProvider = originalPathUtilsProvider as unknown as {
+  register: jest.Mock<void, [Jimpex]>;
+};
+
+export const envUtilsProvider = originalEnvUtilsProvider as unknown as {
+  register: jest.Mock<void, [Jimpex]>;
+};
+
+export const packageInfoProvider = originalPackageInfoProvider as unknown as {
+  register: jest.Mock<void, [Jimpex]>;
+};
+
+export const rootFileProvider = originalRootFileProvider as unknown as {
+  register: jest.Mock<void, [Jimpex]>;
+};
+
+export const simpleConfigProvider =
+  originalSimpleConfigProvider as unknown as jest.MockInstance<
+    ReturnType<typeof originalSimpleConfigProvider>,
+    jest.ArgsType<typeof originalSimpleConfigProvider>
+  >;
+
+export const resetDependencies = (): void => {
+  https.createServer.mockReset();
+  express.mockReset();
+  express.Router.mockReset();
+  express.static.mockReset();
+  compression.mockReset();
+  bodyParser.json.mockReset();
+  bodyParser.urlencoded.mockReset();
+  multer.mockReset();
+  appLoggerProvider.mockReset();
+  simpleConfigProvider.mockReset();
+  pathUtilsProvider.register.mockReset();
+  envUtilsProvider.register.mockReset();
+  packageInfoProvider.register.mockReset();
+  rootFileProvider.register.mockReset();
+};
+
+export type SetupExpressResult = {
+  expressMocks: {
+    enable: jest.Mock<void, []>;
+    disable: jest.Mock<void, []>;
+    use: jest.Mock<void, [ExpressMiddleware]>;
+    listen: jest.Mock<{ close: jest.Mock<void, []> }, [number, () => void]>;
+  };
+  instanceMock: {
+    close: jest.Mock<void, []>;
+  };
+  routerMock: jest.Mock<
+    ReturnType<typeof originalExpress.Router>,
+    Parameters<typeof originalExpress.Router>
+  >;
+  staticMock: jest.Mock<unknown, [string]>;
+  compressionMock: typeof compression;
+  multerMocks: {
+    multer: typeof multer;
+    any: jest.Mock<{ multerAny: boolean }, []>;
+  };
+  bodyParserMocks: {
+    json: jest.Mock<void, []>;
+    urlencoded: jest.Mock<void, []>;
+  };
+};
+
+export const setupExpress = (): SetupExpressResult => {
+  const close = jest.fn();
+  const instanceMock = {
+    express: true,
+    close,
+  };
+  const expressMocks = {
+    express: true,
+    enable: jest.fn(),
+    disable: jest.fn(),
+    use: jest.fn(),
+    listen: jest.fn((_: number, cb: () => void) => {
+      cb();
+      return instanceMock;
+    }),
+  };
+  express.mockReturnValueOnce(expressMocks as unknown as Express);
+  const expressRouterInstance = {
+    router: true,
+  };
+  express.Router.mockReturnValueOnce(expressRouterInstance as unknown as Router);
+  const expressStaticInstance = {
+    static: true,
+  };
+  express.static.mockReturnValue(expressStaticInstance);
+  const compressionInstance = {
+    compression: true,
+  };
+  compression.mockReturnValueOnce(
+    compressionInstance as unknown as ReturnType<typeof originalCompression>,
+  );
+  const bodyParserJsonInstance = {
+    json: true,
+  };
+  bodyParser.json.mockReturnValueOnce(bodyParserJsonInstance);
+  const bodyParserUrlencodedInstance = {
+    urlencoded: true,
+  };
+  bodyParser.urlencoded.mockReturnValueOnce(bodyParserUrlencodedInstance);
+  const multerAnyInstance = {
+    multerAny: true,
+  };
+  const multerInstance = {
+    any: jest.fn(() => multerAnyInstance),
+  };
+  multer.mockReturnValueOnce(
+    multerInstance as unknown as ReturnType<typeof originalMulter>,
+  );
+
+  return {
+    expressMocks,
+    instanceMock,
+    routerMock: express.Router,
+    staticMock: express.static,
+    compressionMock: compression,
+    multerMocks: {
+      multer,
+      any: multerInstance.any,
+    },
+    bodyParserMocks: {
+      json: bodyParser.json,
+      urlencoded: bodyParser.urlencoded,
+    },
+  };
+};
+
+export type SetupWootilsOptions = {
+  pathUtils?: PathUtilsMockOptions;
+};
+
+export type SetupWootilsResult = {
+  pathUtilsMocks: PathUtilsMockMocks;
+  loggerMocks: LoggerMockMocks;
+  configMocks: ConfigMockMocks;
+  config: SimpleConfig;
+};
+
+export const setupWootils = (options: SetupWootilsOptions = {}): SetupWootilsResult => {
+  const { pathUtils: pathUtilsOptions = {} } = options;
+  const { pathUtils, pathUtilsMocks } = getPathUtilsMock(pathUtilsOptions);
+  pathUtilsProvider.register.mockImplementationOnce((c) =>
+    c.set('pathUtils', () => pathUtils),
+  );
+  const { logger, loggerMocks } = getLoggerMock();
+  appLoggerProvider.mockReturnValueOnce({
+    register: (c) => c.set('logger', () => logger),
+    provider: true,
+  });
+  const { config, configMocks } = getConfigMock();
+  simpleConfigProvider.mockReturnValueOnce({
+    register: (c) => c.set('config', () => config),
+    provider: true,
+  });
+
+  return {
+    pathUtilsMocks,
+    loggerMocks,
+    configMocks,
+    config,
+  };
+};
+
+export type SetupServicesOptions = {
+  commonServicesRegister?: (c: Jimpex) => void;
+  httpServicesRegister?: (c: Jimpex) => void;
+  utilsServicesRegister?: (c: Jimpex) => void;
+};
+
+export type SetupServices = {
+  commonServices: jest.SpyInstance<void, [Jimpex]>;
+  httpServices: jest.SpyInstance<void, [Jimpex]>;
+  utilsServices: jest.SpyInstance<void, [Jimpex]>;
+};
+
+export const setupServices = (options: SetupServicesOptions = {}): SetupServices => {
+  const {
+    commonServicesRegister = () => {},
+    httpServicesRegister = () => {},
+    utilsServicesRegister = () => {},
+  } = options;
+  const mocks = {
+    commonServices: jest
+      .spyOn(commonServices, 'register')
+      .mockClear()
+      .mockImplementationOnce(commonServicesRegister),
+    httpServices: jest
+      .spyOn(httpServices, 'register')
+      .mockClear()
+      .mockImplementationOnce(httpServicesRegister),
+    utilsServices: jest
+      .spyOn(utilsServices, 'register')
+      .mockClear()
+      .mockImplementationOnce(utilsServicesRegister),
+  };
+
+  return mocks;
+};
+
+export type SetupCaseOptions = {
+  wootils?: SetupWootilsOptions;
+  services?: SetupServicesOptions;
+};
+
+export type SetupCaseResults = {
+  express: SetupExpressResult;
+  wootils: SetupWootilsResult;
+  services: SetupServices;
+};
+
+export const setupCase = (options: SetupCaseOptions = {}): SetupCaseResults => {
+  const expressSetup = setupExpress();
+  const wootilsSetup = setupWootils(options.wootils);
+  const servicesSetup = setupServices(options.services);
+  return {
+    express: expressSetup,
+    wootils: wootilsSetup,
+    services: servicesSetup,
+  };
+};

--- a/tests/mocks/pathUtils.ts
+++ b/tests/mocks/pathUtils.ts
@@ -1,4 +1,4 @@
-import { PathUtils } from '@homer0/path-utils';
+import type { PathUtils } from '@homer0/path-utils';
 
 type JoinFromMock = jest.Mock<string, [string, string]>;
 
@@ -8,6 +8,7 @@ export type PathUtilsMockOptions = {
 
 export type PathUtilsMockMocks = {
   joinFrom: JoinFromMock;
+  addLocation: jest.Mock<string, string[]>;
 };
 
 export type PathUtilsMockResult = {
@@ -21,15 +22,20 @@ export const getPathUtilsMock = (
   const { joinFrom = jest.fn() } = options;
   const mocks = {
     joinFrom,
+    addLocation: jest.fn(),
   };
-  class MockedPathUtils extends PathUtils {
-    override joinFrom(from: string, filepath: string): string {
+  class MockedPathUtils {
+    joinFrom(from: string, filepath: string): string {
       mocks.joinFrom(from, filepath);
       return filepath;
     }
+
+    addLocation(...args: Parameters<PathUtils['addLocation']>): void {
+      return mocks.addLocation(...args);
+    }
   }
   return {
-    pathUtils: new MockedPathUtils(),
+    pathUtils: new MockedPathUtils() as PathUtils,
     pathUtilsMocks: mocks,
   };
 };

--- a/tests/services/common/index.test.ts
+++ b/tests/services/common/index.test.ts
@@ -1,4 +1,4 @@
-import collection from '@src/services/common';
+import { commonServicesProvider as collection } from '@src/services/common';
 
 const SERVICES = ['appError', 'httpError', 'sendFile'];
 

--- a/tests/services/frontend/index.test.ts
+++ b/tests/services/frontend/index.test.ts
@@ -1,4 +1,4 @@
-import collection from '@src/services/frontend';
+import { frontendServicesProvider as collection } from '@src/services/frontend';
 
 const SERVICES = ['frontendFs'];
 

--- a/tests/services/html/index.test.ts
+++ b/tests/services/html/index.test.ts
@@ -1,4 +1,4 @@
-import collection from '@src/services/html';
+import { htmlServicesProvider as collection } from '@src/services/html';
 
 const SERVICES = ['htmlGenerator'];
 

--- a/tests/services/http/index.test.ts
+++ b/tests/services/http/index.test.ts
@@ -1,4 +1,4 @@
-import collection from '@src/services/http';
+import { httpServicesProvider as collection } from '@src/services/http';
 
 const SERVICES = ['apiClient', 'http', 'responsesBuilder'];
 

--- a/tests/services/index.test.ts
+++ b/tests/services/index.test.ts
@@ -11,11 +11,11 @@ describe('services', () => {
     // Given/When/Then
     expect(services).toEqual(
       expect.objectContaining({
-        common: 'providers',
-        frontend: 'providers',
-        html: 'providers',
-        http: 'providers',
-        utils: 'providers',
+        commonServicesProvider: 'providers',
+        frontendServicesProvider: 'providers',
+        htmlServicesProvider: 'providers',
+        httpServicesProvider: 'providers',
+        utilsServicesProvider: 'providers',
       }),
     );
   });

--- a/tests/services/utils/index.test.ts
+++ b/tests/services/utils/index.test.ts
@@ -1,4 +1,4 @@
-import collection from '@src/services/utils';
+import { utilsServicesProvider as collection } from '@src/services/utils';
 
 const SERVICES = ['ensureBearerToken'];
 

--- a/tests/utils/wrappers.test.ts
+++ b/tests/utils/wrappers.test.ts
@@ -1,4 +1,3 @@
-import { Jimpex } from '@src/app/jimpex';
 import {
   controller,
   controllerCreator,
@@ -9,25 +8,26 @@ import {
   middlewareProvider,
   middlewareProviderCreator,
 } from '@src/utils/wrappers';
+import { getJimpexMock } from '@tests/mocks';
 
-describe('app:resources', () => {
+describe('app:wrappers', () => {
   describe('controllers', () => {
     it('should generate an object with a `connect` function', () => {
       // Given
       const handler = () => {};
       const connect = jest.fn(() => handler);
-      const jimpex = new Jimpex();
+      const { container } = getJimpexMock();
       const route = '/some/path';
       // When
       const sut = controller(connect);
-      const result = sut.connect(jimpex, route);
+      const result = sut.connect(container, route);
       // Then
       expect(sut).toEqual({
         controller: true,
         connect: expect.any(Function),
       });
       expect(result).toBe(handler);
-      expect(connect).toHaveBeenCalledWith(jimpex, route);
+      expect(connect).toHaveBeenCalledWith(container, route);
     });
 
     it('should generate a controller creator', () => {
@@ -35,13 +35,13 @@ describe('app:resources', () => {
       const handler = () => {};
       const connect = jest.fn(() => handler);
       const creator = jest.fn(() => connect);
-      const jimpex = new Jimpex();
+      const { container } = getJimpexMock();
       const route = '/some/path';
       // When
       const sut = controllerCreator(creator);
       const result = sut();
-      const resultFromCreator = result.connect(jimpex, route);
-      const resultAsController = sut.connect(jimpex, route);
+      const resultFromCreator = result.connect(container, route);
+      const resultAsController = sut.connect(container, route);
       // Then
       expect(sut).toEqual(expect.any(Function));
       expect(sut.controller).toBe(true);
@@ -49,7 +49,7 @@ describe('app:resources', () => {
       expect(resultFromCreator).toBe(handler);
       expect(resultAsController).toBe(handler);
       expect(creator).toHaveBeenCalledTimes(2);
-      expect(connect).toHaveBeenCalledWith(jimpex, route);
+      expect(connect).toHaveBeenCalledWith(container, route);
     });
 
     it('should generate a controller provider', () => {
@@ -57,12 +57,12 @@ describe('app:resources', () => {
       const handler = () => {};
       const connect = jest.fn(() => handler);
       const register = jest.fn(() => controller(connect));
-      const jimpex = new Jimpex();
+      const { container } = getJimpexMock();
       const route = '/some/path';
       // When
       const sut = controllerProvider(register);
-      const result = sut.register(jimpex, route);
-      const connectResult = result.connect(jimpex, route);
+      const result = sut.register(container, route);
+      const connectResult = result.connect(container, route);
       // Then
       expect(sut).toEqual({
         provider: true,
@@ -81,14 +81,14 @@ describe('app:resources', () => {
       const connect = jest.fn(() => handler);
       const register = jest.fn(() => controller(connect));
       const creator = jest.fn(() => register);
-      const jimpex = new Jimpex();
+      const { container } = getJimpexMock();
       const route = '/some/path';
       // When
       const sut = controllerProviderCreator(creator);
-      const resultFromCreator = sut().register(jimpex, route);
-      const resultAsProvider = sut.register(jimpex, route);
-      const connectResultFromCreator = resultFromCreator.connect(jimpex, route);
-      const connectResultAsProvider = resultAsProvider.connect(jimpex, route);
+      const resultFromCreator = sut().register(container, route);
+      const resultAsProvider = sut.register(container, route);
+      const connectResultFromCreator = resultFromCreator.connect(container, route);
+      const connectResultAsProvider = resultAsProvider.connect(container, route);
       // Then
       expect(sut).toEqual(expect.any(Function));
       expect(sut.provider).toBe(true);
@@ -111,17 +111,17 @@ describe('app:resources', () => {
       // Given
       const handler = () => {};
       const connect = jest.fn(() => handler);
-      const jimpex = new Jimpex();
+      const { container } = getJimpexMock();
       // When
       const sut = middleware(connect);
-      const result = sut.connect(jimpex);
+      const result = sut.connect(container);
       // Then
       expect(sut).toEqual({
         middleware: true,
         connect: expect.any(Function),
       });
       expect(result).toBe(handler);
-      expect(connect).toHaveBeenCalledWith(jimpex);
+      expect(connect).toHaveBeenCalledWith(container);
     });
 
     it('should generate a middleware creator', () => {
@@ -129,12 +129,12 @@ describe('app:resources', () => {
       const handler = () => {};
       const connect = jest.fn(() => handler);
       const creator = jest.fn(() => connect);
-      const jimpex = new Jimpex();
+      const { container } = getJimpexMock();
       // When
       const sut = middlewareCreator(creator);
       const result = sut();
-      const resultFromCreator = result.connect(jimpex);
-      const resultAsMiddleware = sut.connect(jimpex);
+      const resultFromCreator = result.connect(container);
+      const resultAsMiddleware = sut.connect(container);
       // Then
       expect(sut).toEqual(expect.any(Function));
       expect(sut.middleware).toBe(true);
@@ -142,7 +142,7 @@ describe('app:resources', () => {
       expect(resultFromCreator).toBe(handler);
       expect(resultAsMiddleware).toBe(handler);
       expect(creator).toHaveBeenCalledTimes(2);
-      expect(connect).toHaveBeenCalledWith(jimpex);
+      expect(connect).toHaveBeenCalledWith(container);
     });
 
     it('should generate a middleware provider', () => {
@@ -150,11 +150,11 @@ describe('app:resources', () => {
       const handler = () => {};
       const connect = jest.fn(() => handler);
       const register = jest.fn(() => middleware(connect));
-      const jimpex = new Jimpex();
+      const { container } = getJimpexMock();
       // When
       const sut = middlewareProvider(register);
-      const result = sut.register(jimpex);
-      const connectResult = result.connect(jimpex);
+      const result = sut.register(container);
+      const connectResult = result.connect(container);
       // Then
       expect(sut).toEqual({
         provider: true,
@@ -173,13 +173,13 @@ describe('app:resources', () => {
       const connect = jest.fn(() => handler);
       const register = jest.fn(() => middleware(connect));
       const creator = jest.fn(() => register);
-      const jimpex = new Jimpex();
+      const { container } = getJimpexMock();
       // When
       const sut = middlewareProviderCreator(creator);
-      const resultFromCreator = sut().register(jimpex);
-      const resultAsProvider = sut.register(jimpex);
-      const connectResultFromCreator = resultFromCreator.connect(jimpex);
-      const connectResultAsProvider = resultAsProvider.connect(jimpex);
+      const resultFromCreator = sut().register(container);
+      const resultAsProvider = sut.register(container);
+      const connectResultFromCreator = resultFromCreator.connect(container);
+      const connectResultAsProvider = resultAsProvider.connect(container);
       // Then
       expect(sut).toEqual(expect.any(Function));
       expect(sut.provider).toBe(true);


### PR DESCRIPTION
### What does this PR do?

- Restored the functionality that registers the default services.
- Added the `path.appPath` option to solve the issue with `PathUtils` and ESM.
- Added unit tests for the main class.

### How should it be tested manually?

```bash
npm test
```
